### PR TITLE
LDAP provisioning feature for WSO2 Identiy Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # identity-inbound-provisioning-ldap
+
+LDAP is a core protocol that is used to store user, role, and group information.The idea of this project is to make Identity Server itself act as a LDAP protocol provider.

--- a/components/org.wso2.carbon.identity.inbound.ldap/pom.xml
+++ b/components/org.wso2.carbon.identity.inbound.ldap/pom.xml
@@ -1,0 +1,280 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <parent>
+        <groupId>org.wso2.carbon.identity.inbound.provisioning.ldap</groupId>
+        <artifactId>identity-inbound-provisioning-ldap</artifactId>
+        <relativePath>../../pom.xml</relativePath>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>identity-inbound-provisioning-ldap</groupId>
+    <packaging>bundle</packaging>
+    <artifactId>org.wso2.carbon.identity.inbound.ldap</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.wso2.carbon</groupId>
+            <artifactId>org.wso2.carbon.core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.base</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>log4j-over-slf4j</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>jcl-over-slf4j</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.orbit.org.apache.directory</groupId>
+            <artifactId>apacheds</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+        </dependency>
+
+        <dependency>
+            <artifactId>apacheds-protocol-ldap</artifactId>
+            <groupId>org.apache.directory.server</groupId>
+        </dependency>
+
+        <dependency>
+            <artifactId>apacheds-protocol-kerberos</artifactId>
+            <groupId>org.apache.directory.server</groupId>
+        </dependency>
+
+        <dependency>
+            <artifactId>apacheds-interceptor-kerberos</artifactId>
+            <groupId>org.apache.directory.server</groupId>
+        </dependency>
+
+        <dependency>
+            <artifactId>apacheds-core-annotations</artifactId>
+            <groupId>org.apache.directory.server</groupId>
+        </dependency>
+
+        <dependency>
+            <artifactId>api-ldap-model</artifactId>
+            <groupId>org.apache.directory.api</groupId>
+        </dependency>
+
+        <dependency>
+            <artifactId>api-util</artifactId>
+            <groupId>org.apache.directory.api</groupId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.apache.felix.scr.ds-annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.w3c</groupId>
+            <artifactId>dom</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.wso2.carbon.identity</groupId>
+            <artifactId>org.wso2.carbon.identity.application.common</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.wso2.carbon.identity</groupId>
+            <artifactId>org.wso2.carbon.identity.application.mgt</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <!--Test Dependencies-->
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jacoco</groupId>
+            <artifactId>org.jacoco.agent</artifactId>
+            <classifier>runtime</classifier>
+            <scope>test</scope>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/org.powermock/powermock-module-testng -->
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-module-testng</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-api-mockito</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-scr-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>generate-scr-scrdescriptor</id>
+                        <goals>
+                            <goal>scr</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Private-Package>
+                            org.wso2.carbon.identity.inbound.ldap.impl.*,
+                            org.wso2.carbon.identity.inbound.ldap.interceptor.*,
+                            org.wso2.carbon.identity.inbound.ldap.utils.*,
+                            org.wso2.carbon.identity.inbound.ldap.provider.*,
+                            org.wso2.carbon.identity.inbound.ldap.internal.*,
+                            apachedsServer.*;
+                        </Private-Package>
+                        <Import-Package>
+                            javax.naming,
+                            javax.naming.ldap,
+                            javax.naming.directory,
+                            javax.xml.namespace,
+                            javax.xml.stream,
+                            org.w3c.dom,
+
+                            org.slf4j; version="${org.slf4j.imp.pkg.version.range}",
+
+                            org.apache.axiom.*; version="${axiom.osgi.version.range}",
+                            org.apache.log4j; version="${carbon.logging.imp.pkg.version.range}",
+                            org.apache.commons.io; version="${commons.io.wso2.osgi.version.range}",
+
+                            org.apache.directory.server.*; version="${apacheds.imp.pkg.version.range}",
+                            org.apache.directory.shared.*; version="${apacheds.imp.pkg.version.range}",
+
+                            org.osgi.framework; version="${osgi.framework.imp.pkg.version.range}",
+                            org.osgi.service.component.*;version="${osgi.service.component.imp.pkg.version.range}",
+
+
+                            org.wso2.carbon.identity.application.*;version="${org.wso2.carbon.identity.application.version}",
+                            org.wso2.carbon.user.core.*;version="${carbon.kernel.package.import.version.range}",
+                            org.wso2.carbon.utils;version="${carbon.kernel.package.import.version.range}",
+                            org.wso2.carbon.user.api; version="${carbon.user.api.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.base;
+                            version="${carbon.identity.framework.package.import.version.range}"
+                        </Import-Package>
+                        <Export-Package>
+                            !org.wso2.carbon.identity.inbound.ldap.impl.*,
+                            !org.wso2.carbon.identity.inbound.ldap.interceptor.*,
+                            !org.wso2.carbon.identity.inbound.ldap.utils.*,
+                            !org.wso2.carbon.identity.inbound.ldap.provider.*,
+                            !org.wso2.carbon.identity.inbound.ldap.internal.*,
+                            !apachedsServer.*,
+                            org.wso2.carbon.identity.inbound.ldap.*;
+                            version="${org.wso2.carbon.identity.inbound.ldap.package.export.version}"
+                        </Export-Package>
+                        <DynamicImport-Package>*</DynamicImport-Package>
+                        <DeployBefore>UserCore</DeployBefore>
+                    </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>${jacoco.version}</version>
+                <executions>
+                    <execution>
+                        <id>default-prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>default-prepare-agent-integration</id>
+                        <goals>
+                            <goal>prepare-agent-integration</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>default-report</id>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>default-report-integration</id>
+                        <goals>
+                            <goal>report-integration</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>default-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <rule implementation="org.jacoco.maven.RuleConfiguration">
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit implementation="org.jacoco.report.check.Limit">
+                                            <counter>COMPLEXITY</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.00</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/components/org.wso2.carbon.identity.inbound.ldap/pom.xml
+++ b/components/org.wso2.carbon.identity.inbound.ldap/pom.xml
@@ -201,7 +201,6 @@
                             org.osgi.framework; version="${osgi.framework.imp.pkg.version.range}",
                             org.osgi.service.component.*;version="${osgi.service.component.imp.pkg.version.range}",
 
-
                             org.wso2.carbon.identity.application.*;version="${org.wso2.carbon.identity.application.version}",
                             org.wso2.carbon.user.core.*;version="${carbon.kernel.package.import.version.range}",
                             org.wso2.carbon.utils;version="${carbon.kernel.package.import.version.range}",

--- a/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/impl/ApacheLDAPServer.java
+++ b/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/impl/ApacheLDAPServer.java
@@ -57,7 +57,6 @@ import java.util.Map;
  */
 public class ApacheLDAPServer implements LDAPServer {
 
-
     private static final Log log = LogFactory.getLog(ApacheLDAPServer.class);
     private static ApacheLDAPServer apacheLDAPServer = new ApacheLDAPServer();
     Map<String, MechanismHandler> mechanismHandlerMap;
@@ -97,7 +96,6 @@ public class ApacheLDAPServer implements LDAPServer {
         }
 
     }
-
 
     @Override
     public void start()
@@ -325,15 +323,11 @@ public class ApacheLDAPServer implements LDAPServer {
 
         // Add interceptors
         List<Interceptor> list = this.service.getInterceptors();
-        // list.add(new KeyDerivationInterceptor());
         list.add(0, new WSO2Interceptor());
-
         this.service.setInterceptors(list);
-
     }
 
-    protected void initializeLDAPServer()
-            throws Exception {
+    protected void initializeLDAPServer() throws Exception {
 
         try {
             if (null == this.service || null == this.endPointConfigurations) {
@@ -380,10 +374,5 @@ public class ApacheLDAPServer implements LDAPServer {
 
         this.ldapServer.setSaslMechanismHandlers(mechanismHandlerMap);
     }
-
-    /* This method we can use for the get ldapSession
-    public LdapSession[] getLdapSessions(){
-        return ldapServer.getLdapSessionManager().getSessions();
-    }*/
 
 }

--- a/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/impl/ApacheLDAPServer.java
+++ b/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/impl/ApacheLDAPServer.java
@@ -184,7 +184,7 @@ public class ApacheLDAPServer implements LDAPServer {
         try {
             adminPrinciple = getAdminPrinciple();
         } catch (Exception e) {
-            String msg="Can not get the connection domain name" ;
+            String msg = "Can not get the connection domain name";
             throw new IdentityLdapException(msg);
         }
         return adminPrinciple.getClonedName().getName();
@@ -195,7 +195,7 @@ public class ApacheLDAPServer implements LDAPServer {
 
         if (this.service != null) {
             CoreSession adminSession;
-                adminSession = getAdminSession(this.service);
+            adminSession = getAdminSession(this.service);
             if (adminSession != null) {
                 LdapPrincipal adminPrincipal = adminSession.getAuthenticatedPrincipal();
                 if (adminPrincipal != null) {
@@ -227,7 +227,7 @@ public class ApacheLDAPServer implements LDAPServer {
         if (this.service != null) {
             CoreSession adminSession;
 
-                adminSession = getAdminSession(this.service);
+            adminSession = getAdminSession(this.service);
 
             if (adminSession != null) {
                 LdapPrincipal adminPrincipal = adminSession.getAuthenticatedPrincipal();
@@ -240,23 +240,23 @@ public class ApacheLDAPServer implements LDAPServer {
                     try {
                         messageDigest = MessageDigest.getInstance(
                                 ConfigurationConstants.ADMIN_PASSWORD_ALGORITHM);
-                    messageDigest.update(password.getBytes());
-                    byte[] bytes = messageDigest.digest();
-                    String hash = Base64.encode(bytes);
-                    passwordToStore = passwordToStore + hash;
+                        messageDigest.update(password.getBytes());
+                        byte[] bytes = messageDigest.digest();
+                        String hash = Base64.encode(bytes);
+                        passwordToStore = passwordToStore + hash;
 
-                    adminPrincipal.setUserPassword(passwordToStore.getBytes());
+                        adminPrincipal.setUserPassword(passwordToStore.getBytes());
 
-                    EntryAttribute passwordAttribute = new DefaultServerAttribute(
-                            getAttributeType("userPassword"));
-                    passwordAttribute.add(passwordToStore.getBytes());
+                        EntryAttribute passwordAttribute = new DefaultServerAttribute(
+                                getAttributeType("userPassword"));
+                        passwordAttribute.add(passwordToStore.getBytes());
 
-                    ServerModification serverModification =
-                            new ServerModification(ModificationOperation.REPLACE_ATTRIBUTE,
-                                    passwordAttribute);
+                        ServerModification serverModification =
+                                new ServerModification(ModificationOperation.REPLACE_ATTRIBUTE,
+                                        passwordAttribute);
 
-                    List<Modification> modifiedList = new ArrayList<Modification>();
-                    modifiedList.add(serverModification);
+                        List<Modification> modifiedList = new ArrayList<Modification>();
+                        modifiedList.add(serverModification);
                         adminSession.modify(adminPrincipal.getClonedName(), modifiedList);
                     } catch (NoSuchAlgorithmException e) {
                         throw new IdentityLdapException(

--- a/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/impl/ApacheLDAPServer.java
+++ b/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/impl/ApacheLDAPServer.java
@@ -1,0 +1,388 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.carbon.identity.inbound.ldap.impl;
+
+import org.apache.axiom.om.util.Base64;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.directory.server.core.CoreSession;
+import org.apache.directory.server.core.DirectoryService;
+import org.apache.directory.server.core.LdapPrincipal;
+import org.apache.directory.server.core.factory.DirectoryServiceFactory;
+import org.apache.directory.server.core.interceptor.Interceptor;
+import org.apache.directory.server.ldap.LdapServer;
+import org.apache.directory.server.ldap.handlers.bind.MechanismHandler;
+import org.apache.directory.server.ldap.handlers.bind.cramMD5.CramMd5MechanismHandler;
+import org.apache.directory.server.ldap.handlers.bind.digestMD5.DigestMd5MechanismHandler;
+import org.apache.directory.server.ldap.handlers.bind.gssapi.GssapiMechanismHandler;
+import org.apache.directory.server.ldap.handlers.bind.ntlm.NtlmMechanismHandler;
+import org.apache.directory.server.ldap.handlers.bind.plain.PlainMechanismHandler;
+import org.apache.directory.server.protocol.shared.transport.TcpTransport;
+import org.apache.directory.shared.ldap.constants.SupportedSaslMechanisms;
+import org.apache.directory.shared.ldap.entry.DefaultServerAttribute;
+import org.apache.directory.shared.ldap.entry.EntryAttribute;
+import org.apache.directory.shared.ldap.entry.Modification;
+import org.apache.directory.shared.ldap.entry.ModificationOperation;
+import org.apache.directory.shared.ldap.entry.ServerModification;
+import org.apache.directory.shared.ldap.schema.AttributeType;
+import org.apache.directory.shared.ldap.schema.SchemaManager;
+import org.apache.directory.shared.ldap.schema.registries.AttributeTypeRegistry;
+import org.wso2.carbon.identity.inbound.ldap.interceptor.WSO2Interceptor;
+import org.wso2.carbon.identity.inbound.ldap.utils.IdentityLdapException;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * An implementation of LDAP server. This wraps apacheds implementation and provides an
+ * abstract interface to operate on directory server.
+ */
+public class ApacheLDAPServer implements LDAPServer {
+
+
+    private static final Log log = LogFactory.getLog(ApacheLDAPServer.class);
+    private static ApacheLDAPServer apacheLDAPServer = new ApacheLDAPServer();
+    Map<String, MechanismHandler> mechanismHandlerMap;
+    private DirectoryService service;
+    private LdapServer ldapServer;
+    private EndPointConfiguration endPointConfigurations;
+
+    private ApacheLDAPServer() {
+    }
+
+    public static ApacheLDAPServer getApacheLDAPServer() {
+        return apacheLDAPServer;
+    }
+
+    @Override
+    public void init(EndPointConfiguration configurations)
+            throws IdentityLdapException {
+
+        if (configurations == null) {
+            log.error("LDAP org.wso2.carbon.identity.inbound.ldap.provider initialization failed. " +
+                    "LDAP org.wso2.carbon.identity.inbound.ldap.provider configuration is invalid.");
+            throw new IdentityLdapException("Cannot initialize LDAP org.wso2.carbon.identity.inbound.ldap.provider " +
+                    "Configuration is null");
+        }
+
+        this.endPointConfigurations = configurations;
+
+        try {
+
+            initializeDefaultDirectoryService();
+            initializeLDAPServer();
+
+        } catch (Exception e) {
+            log.error("LDAP org.wso2.carbon.identity.inbound.ldap.provider initialization failed.", e);
+            throw new IdentityLdapException("Error initializing ApacheLDAP org.wso2.carbon.identity.inbound.ldap.provider. ", e);
+        }
+
+    }
+
+
+    @Override
+    public void start()
+            throws IdentityLdapException {
+
+        try {
+            this.service.startup();
+            this.ldapServer.start();
+
+            log.info("LDAP org.wso2.carbon.identity.inbound.ldap.provider started.");
+        } catch (Exception e) {
+
+            log.error("Error starting LDAP org.wso2.carbon.identity.inbound.ldap.provider.", e);
+            throw new IdentityLdapException("Can not start the ldap org.wso2.carbon.identity.inbound.ldap.provider ", e);
+        }
+    }
+
+    @Override
+    public void stop()
+            throws IdentityLdapException {
+
+        try {
+
+            this.ldapServer.stop();
+            this.service.shutdown();
+            log.info("LDAP org.wso2.carbon.identity.inbound.ldap.provider stopped.");
+        } catch (Exception e) {
+
+            log.error("Error stopping LDAP org.wso2.carbon.identity.inbound.ldap.provider.", e);
+            throw new IdentityLdapException("Can not start the ldapendpoint", e);
+        }
+    }
+
+    protected void initializeDefaultDirectoryService()
+            throws IdentityLdapException {
+        try {
+
+            DirectoryServiceFactory factory = CarbonDirectoryServiceFactory.DEFAULT;
+            this.service = factory.getDirectoryService();
+
+            configureDirectoryService();
+
+            factory.init(this.endPointConfigurations.getInstanceId());
+
+        } catch (Exception e) {
+            throw new IdentityLdapException("Can not start the Default apacheds service ", e);
+        }
+    }
+
+    private AttributeType getAttributeType(String attributeName)
+            throws IdentityLdapException {
+        if (this.service != null) {
+            SchemaManager schemaManager = this.service.getSchemaManager();
+            if (schemaManager != null) {
+                AttributeTypeRegistry registry = schemaManager.getAttributeTypeRegistry();
+                if (registry != null) {
+                    try {
+                        String oid = registry.getOidByName(attributeName);
+                        return registry.lookup(oid);
+                    } catch (Exception e) {
+                        String msg = "An error occurred while querying attribute " + attributeName +
+                                " from registry.";
+                        log.error(msg, e);
+                        throw new IdentityLdapException(msg, e);
+                    }
+                } else {
+                    String msg = "Could not get attribute registry.";
+                    log.error(msg);
+                    throw new IdentityLdapException(msg);
+
+                }
+
+            } else {
+                String msg = "Cannot access schema manager. Directory server may not have started.";
+                log.error(msg);
+                throw new IdentityLdapException(msg);
+
+            }
+        } else {
+            String msg = "The directory service is null. LDAP server might not have started.";
+            log.error(msg);
+            throw new IdentityLdapException(msg);
+
+        }
+    }
+
+    @Override
+    public String getConnectionDomainName()
+            throws Exception {
+
+        LdapPrincipal adminPrinciple = getAdminPrinciple();
+        return adminPrinciple.getClonedName().getName();
+    }
+
+    private LdapPrincipal getAdminPrinciple()
+            throws Exception {
+
+        if (this.service != null) {
+            CoreSession adminSession;
+            try {
+                adminSession = this.service.getAdminSession();
+            } catch (Exception e) {
+                String msg = "An error occurred while retraining admin session.";
+                log.error(msg, e);
+                throw new Exception(msg, e);
+            }
+            if (adminSession != null) {
+                LdapPrincipal adminPrincipal = adminSession.getAuthenticatedPrincipal();
+                if (adminPrincipal != null) {
+                    return adminPrincipal;
+                } else {
+                    String msg = "Could not retrieve admin principle. Failed changing connection " +
+                            "user password.";
+                    log.error(msg);
+                    throw new Exception(msg);
+                }
+            } else {
+                String msg = "Directory admin session is null. The LDAP server may not have " +
+                        "started yet.";
+                log.error(msg);
+                throw new Exception(msg);
+            }
+        } else {
+
+            String msg = "Directory service is null. The LDAP server may not have started yet.";
+            log.error(msg);
+            throw new Exception(msg);
+        }
+
+    }
+
+    @Override
+    public void changeConnectionUserPassword(String password)
+            throws Exception {
+
+        if (this.service != null) {
+            CoreSession adminSession;
+            try {
+                adminSession = this.service.getAdminSession();
+            } catch (Exception e) {
+                String msg = "An error occurred while retraining admin session.";
+                log.error(msg, e);
+                throw new Exception(msg, e);
+            }
+            if (adminSession != null) {
+                LdapPrincipal adminPrincipal = adminSession.getAuthenticatedPrincipal();
+                if (adminPrincipal != null) {
+
+                    String passwordToStore = "{" + ConfigurationConstants.ADMIN_PASSWORD_ALGORITHM +
+                            "}";
+
+                    MessageDigest messageDigest;
+                    try {
+                        messageDigest = MessageDigest.getInstance(
+                                ConfigurationConstants.ADMIN_PASSWORD_ALGORITHM);
+                    } catch (NoSuchAlgorithmException e) {
+                        throw new Exception(
+                                "Could not find digest algorithm - " +
+                                        ConfigurationConstants.ADMIN_PASSWORD_ALGORITHM, e);
+                    }
+                    messageDigest.update(password.getBytes());
+                    byte[] bytes = messageDigest.digest();
+                    String hash = Base64.encode(bytes);
+                    passwordToStore = passwordToStore + hash;
+
+                    adminPrincipal.setUserPassword(passwordToStore.getBytes());
+
+                    EntryAttribute passwordAttribute = new DefaultServerAttribute(
+                            getAttributeType("userPassword"));
+                    passwordAttribute.add(passwordToStore.getBytes());
+
+                    ServerModification serverModification =
+                            new ServerModification(ModificationOperation.REPLACE_ATTRIBUTE,
+                                    passwordAttribute);
+
+                    List<Modification> modifiedList = new ArrayList<Modification>();
+                    modifiedList.add(serverModification);
+
+                    try {
+                        adminSession.modify(adminPrincipal.getClonedName(), modifiedList);
+                    } catch (Exception e) {
+                        String msg = "Failed changing connection user password.";
+                        log.error(msg, e);
+                        throw new Exception(msg, e);
+                    }
+
+                } else {
+                    String msg = "Could not retrieve admin principle. Failed changing connection " +
+                            "user password.";
+                    log.error(msg);
+                    throw new Exception(msg);
+                }
+            } else {
+                String msg = "Directory admin session is null. The LDAP server may not have " +
+                        "started yet.";
+                log.error(msg);
+                throw new Exception(msg);
+            }
+        } else {
+            String msg = "Directory service is null. The LDAP server may not have started yet.";
+            log.error(msg);
+            throw new Exception(msg);
+        }
+
+    }
+
+    private void configureDirectoryService()
+            throws Exception {
+
+        if (null == this.endPointConfigurations) {
+            throw new Exception("Directory service is not initialized.");
+        }
+
+        System.setProperty("workingDirectory", this.endPointConfigurations.getWorkingDirectory());
+
+        this.service.setShutdownHookEnabled(false);
+
+        this.service.setInstanceId(this.endPointConfigurations.getInstanceId());
+        this.service.setAllowAnonymousAccess(this.endPointConfigurations.isAllowAnonymousAccess());
+        this.service.setAccessControlEnabled(this.endPointConfigurations.isAccessControlOn());
+        this.service.setDenormalizeOpAttrsEnabled(
+                this.endPointConfigurations.isDeNormalizedAttributesEnabled());
+        this.service.setMaxPDUSize(this.endPointConfigurations.getMaxPDUSize());
+
+
+        // Add interceptors
+        List<Interceptor> list = this.service.getInterceptors();
+        // list.add(new KeyDerivationInterceptor());
+        list.add(0, new WSO2Interceptor());
+
+        this.service.setInterceptors(list);
+
+    }
+
+    protected void initializeLDAPServer()
+            throws Exception {
+
+        try {
+            if (null == this.service || null == this.endPointConfigurations) {
+                throw new Exception(
+                        "The default apacheds service is not initialized. " +
+                                "Make sure apacheds service is initialized first.");
+            }
+
+            this.ldapServer = new LdapServer();
+
+            this.ldapServer.setTransports(new TcpTransport(this.endPointConfigurations.getEndpointPort()));
+
+            // set server initial properties
+            this.ldapServer.setAllowAnonymousAccess(true);
+            this.ldapServer.setSaslHost(this.endPointConfigurations.getSaslHostName());
+            this.ldapServer.setSaslPrincipal(this.endPointConfigurations.getSaslPrincipalName());
+            this.ldapServer.setDirectoryService(this.service);
+
+            setupSaslMechanisms();
+
+        } catch (Exception e) {
+            throw new Exception("can not add the extension handlers ", e);
+        }
+    }
+
+    private void setupSaslMechanisms() {
+        mechanismHandlerMap = new HashMap<String, MechanismHandler>();
+
+        mechanismHandlerMap.put(SupportedSaslMechanisms.PLAIN, new PlainMechanismHandler());
+
+        CramMd5MechanismHandler cramMd5MechanismHandler = new CramMd5MechanismHandler();
+        mechanismHandlerMap.put(SupportedSaslMechanisms.CRAM_MD5, cramMd5MechanismHandler);
+
+        DigestMd5MechanismHandler digestMd5MechanismHandler = new DigestMd5MechanismHandler();
+        mechanismHandlerMap.put(SupportedSaslMechanisms.DIGEST_MD5, digestMd5MechanismHandler);
+
+        GssapiMechanismHandler gssapiMechanismHandler = new GssapiMechanismHandler();
+        mechanismHandlerMap.put(SupportedSaslMechanisms.GSSAPI, gssapiMechanismHandler);
+
+        NtlmMechanismHandler ntlmMechanismHandler = new NtlmMechanismHandler();
+
+        mechanismHandlerMap.put(SupportedSaslMechanisms.NTLM, ntlmMechanismHandler);
+        mechanismHandlerMap.put(SupportedSaslMechanisms.GSS_SPNEGO, ntlmMechanismHandler);
+
+        this.ldapServer.setSaslMechanismHandlers(mechanismHandlerMap);
+    }
+
+    /* This method we can use for the get ldapSession
+    public LdapSession[] getLdapSessions(){
+        return ldapServer.getLdapSessionManager().getSessions();
+    }*/
+
+}

--- a/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/impl/ApacheLDAPServer.java
+++ b/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/impl/ApacheLDAPServer.java
@@ -72,8 +72,7 @@ public class ApacheLDAPServer implements LDAPServer {
     }
 
     @Override
-    public void init(EndPointConfiguration configurations)
-            throws IdentityLdapException {
+    public void init(EndPointConfiguration configurations) throws IdentityLdapException {
 
         if (configurations == null) {
             log.error("LDAP org.wso2.carbon.identity.inbound.ldap.provider initialization failed. " +
@@ -98,8 +97,7 @@ public class ApacheLDAPServer implements LDAPServer {
     }
 
     @Override
-    public void start()
-            throws IdentityLdapException {
+    public void start() throws IdentityLdapException {
 
         try {
             this.service.startup();
@@ -114,8 +112,7 @@ public class ApacheLDAPServer implements LDAPServer {
     }
 
     @Override
-    public void stop()
-            throws IdentityLdapException {
+    public void stop() throws IdentityLdapException {
 
         try {
 
@@ -129,8 +126,7 @@ public class ApacheLDAPServer implements LDAPServer {
         }
     }
 
-    protected void initializeDefaultDirectoryService()
-            throws IdentityLdapException {
+    protected void initializeDefaultDirectoryService() throws IdentityLdapException {
         try {
 
             DirectoryServiceFactory factory = CarbonDirectoryServiceFactory.DEFAULT;
@@ -145,8 +141,7 @@ public class ApacheLDAPServer implements LDAPServer {
         }
     }
 
-    private AttributeType getAttributeType(String attributeName)
-            throws IdentityLdapException {
+    private AttributeType getAttributeType(String attributeName) throws IdentityLdapException {
         if (this.service != null) {
             SchemaManager schemaManager = this.service.getSchemaManager();
             if (schemaManager != null) {
@@ -183,8 +178,7 @@ public class ApacheLDAPServer implements LDAPServer {
     }
 
     @Override
-    public String getConnectionDomainName()
-            throws IdentityLdapException {
+    public String getConnectionDomainName() throws IdentityLdapException {
 
         LdapPrincipal adminPrinciple = null;
         try {
@@ -228,8 +222,7 @@ public class ApacheLDAPServer implements LDAPServer {
     }
 
     @Override
-    public void changeConnectionUserPassword(String password)
-            throws Exception {
+    public void changeConnectionUserPassword(String password) throws Exception {
 
         if (this.service != null) {
             CoreSession adminSession;
@@ -305,8 +298,7 @@ public class ApacheLDAPServer implements LDAPServer {
         }
     }
 
-    private void configureDirectoryService()
-            throws IdentityLdapException {
+    private void configureDirectoryService() throws IdentityLdapException {
 
         if (null == this.endPointConfigurations) {
             throw new IdentityLdapException("Directory service is not initialized.");

--- a/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/impl/ApacheLDAPServer.java
+++ b/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/impl/ApacheLDAPServer.java
@@ -1,0 +1,389 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.carbon.identity.inbound.ldap.impl;
+
+import org.apache.axiom.om.util.Base64;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.directory.server.core.CoreSession;
+import org.apache.directory.server.core.DirectoryService;
+import org.apache.directory.server.core.LdapPrincipal;
+import org.apache.directory.server.core.factory.DirectoryServiceFactory;
+import org.apache.directory.server.core.interceptor.Interceptor;
+import org.apache.directory.server.ldap.LdapServer;
+import org.apache.directory.server.ldap.handlers.bind.MechanismHandler;
+import org.apache.directory.server.ldap.handlers.bind.cramMD5.CramMd5MechanismHandler;
+import org.apache.directory.server.ldap.handlers.bind.digestMD5.DigestMd5MechanismHandler;
+import org.apache.directory.server.ldap.handlers.bind.gssapi.GssapiMechanismHandler;
+import org.apache.directory.server.ldap.handlers.bind.ntlm.NtlmMechanismHandler;
+import org.apache.directory.server.ldap.handlers.bind.plain.PlainMechanismHandler;
+import org.apache.directory.server.protocol.shared.transport.TcpTransport;
+import org.apache.directory.shared.ldap.constants.SupportedSaslMechanisms;
+import org.apache.directory.shared.ldap.entry.DefaultServerAttribute;
+import org.apache.directory.shared.ldap.entry.EntryAttribute;
+import org.apache.directory.shared.ldap.entry.Modification;
+import org.apache.directory.shared.ldap.entry.ModificationOperation;
+import org.apache.directory.shared.ldap.entry.ServerModification;
+import org.apache.directory.shared.ldap.schema.AttributeType;
+import org.apache.directory.shared.ldap.schema.SchemaManager;
+import org.apache.directory.shared.ldap.schema.registries.AttributeTypeRegistry;
+import org.wso2.carbon.identity.inbound.ldap.interceptor.WSO2Interceptor;
+import org.wso2.carbon.identity.inbound.ldap.utils.IdentityLdapException;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * An implementation of LDAP server. This wraps apacheds implementation and provides an
+ * abstract interface to operate on directory server.
+ */
+public class ApacheLDAPServer implements LDAPServer {
+
+
+    private static final Log log = LogFactory.getLog(ApacheLDAPServer.class);
+    private static ApacheLDAPServer apacheLDAPServer = new ApacheLDAPServer();
+    Map<String, MechanismHandler> mechanismHandlerMap;
+    private DirectoryService service;
+    private LdapServer ldapServer;
+    private EndPointConfiguration endPointConfigurations;
+
+    private ApacheLDAPServer() {
+    }
+
+    public static ApacheLDAPServer getApacheLDAPServer() {
+        return apacheLDAPServer;
+    }
+
+    @Override
+    public void init(EndPointConfiguration configurations)
+            throws IdentityLdapException {
+
+        if (configurations == null) {
+            log.error("LDAP org.wso2.carbon.identity.inbound.ldap.provider initialization failed. " +
+                    "LDAP org.wso2.carbon.identity.inbound.ldap.provider configuration is invalid.");
+            throw new IdentityLdapException("Cannot initialize LDAP org.wso2.carbon.identity.inbound.ldap.provider " +
+                    "Configuration is null");
+        }
+
+        this.endPointConfigurations = configurations;
+
+        try {
+
+            initializeDefaultDirectoryService();
+            initializeLDAPServer();
+
+        } catch (Exception e) {
+            log.error("LDAP org.wso2.carbon.identity.inbound.ldap.provider initialization failed.", e);
+            throw new IdentityLdapException("Error initializing ApacheLDAP org.wso2.carbon." +
+                    "identity.inbound.ldap.provider. ", e);
+        }
+
+    }
+
+
+    @Override
+    public void start()
+            throws IdentityLdapException {
+
+        try {
+            this.service.startup();
+            this.ldapServer.start();
+
+            log.info("LDAP org.wso2.carbon.identity.inbound.ldap.provider started.");
+        } catch (Exception e) {
+
+            log.error("Error starting LDAP org.wso2.carbon.identity.inbound.ldap.provider.", e);
+            throw new IdentityLdapException("Can not start the ldap org.wso2.carbon.identity.inbound.ldap.provider ", e);
+        }
+    }
+
+    @Override
+    public void stop()
+            throws IdentityLdapException {
+
+        try {
+
+            this.ldapServer.stop();
+            this.service.shutdown();
+            log.info("LDAP org.wso2.carbon.identity.inbound.ldap.provider stopped.");
+        } catch (Exception e) {
+
+            log.error("Error stopping LDAP org.wso2.carbon.identity.inbound.ldap.provider.", e);
+            throw new IdentityLdapException("Can not start the ldapendpoint", e);
+        }
+    }
+
+    protected void initializeDefaultDirectoryService()
+            throws IdentityLdapException {
+        try {
+
+            DirectoryServiceFactory factory = CarbonDirectoryServiceFactory.DEFAULT;
+            this.service = factory.getDirectoryService();
+
+            configureDirectoryService();
+
+            factory.init(this.endPointConfigurations.getInstanceId());
+
+        } catch (Exception e) {
+            throw new IdentityLdapException("Can not start the Default apacheds service ", e);
+        }
+    }
+
+    private AttributeType getAttributeType(String attributeName)
+            throws IdentityLdapException {
+        if (this.service != null) {
+            SchemaManager schemaManager = this.service.getSchemaManager();
+            if (schemaManager != null) {
+                AttributeTypeRegistry registry = schemaManager.getAttributeTypeRegistry();
+                if (registry != null) {
+                    try {
+                        String oid = registry.getOidByName(attributeName);
+                        return registry.lookup(oid);
+                    } catch (Exception e) {
+                        String msg = "An error occurred while querying attribute " + attributeName +
+                                " from registry.";
+                        log.error(msg, e);
+                        throw new IdentityLdapException(msg, e);
+                    }
+                } else {
+                    String msg = "Could not get attribute registry.";
+                    log.error(msg);
+                    throw new IdentityLdapException(msg);
+
+                }
+
+            } else {
+                String msg = "Cannot access schema manager. Directory server may not have started.";
+                log.error(msg);
+                throw new IdentityLdapException(msg);
+
+            }
+        } else {
+            String msg = "The directory service is null. LDAP server might not have started.";
+            log.error(msg);
+            throw new IdentityLdapException(msg);
+
+        }
+    }
+
+    @Override
+    public String getConnectionDomainName()
+            throws Exception {
+
+        LdapPrincipal adminPrinciple = getAdminPrinciple();
+        return adminPrinciple.getClonedName().getName();
+    }
+
+    private LdapPrincipal getAdminPrinciple()
+            throws Exception {
+
+        if (this.service != null) {
+            CoreSession adminSession;
+            try {
+                adminSession = this.service.getAdminSession();
+            } catch (Exception e) {
+                String msg = "An error occurred while retraining admin session.";
+                log.error(msg, e);
+                throw new Exception(msg, e);
+            }
+            if (adminSession != null) {
+                LdapPrincipal adminPrincipal = adminSession.getAuthenticatedPrincipal();
+                if (adminPrincipal != null) {
+                    return adminPrincipal;
+                } else {
+                    String msg = "Could not retrieve admin principle. Failed changing connection " +
+                            "user password.";
+                    log.error(msg);
+                    throw new Exception(msg);
+                }
+            } else {
+                String msg = "Directory admin session is null. The LDAP server may not have " +
+                        "started yet.";
+                log.error(msg);
+                throw new Exception(msg);
+            }
+        } else {
+
+            String msg = "Directory service is null. The LDAP server may not have started yet.";
+            log.error(msg);
+            throw new Exception(msg);
+        }
+
+    }
+
+    @Override
+    public void changeConnectionUserPassword(String password)
+            throws Exception {
+
+        if (this.service != null) {
+            CoreSession adminSession;
+            try {
+                adminSession = this.service.getAdminSession();
+            } catch (Exception e) {
+                String msg = "An error occurred while retraining admin session.";
+                log.error(msg, e);
+                throw new Exception(msg, e);
+            }
+            if (adminSession != null) {
+                LdapPrincipal adminPrincipal = adminSession.getAuthenticatedPrincipal();
+                if (adminPrincipal != null) {
+
+                    String passwordToStore = "{" + ConfigurationConstants.ADMIN_PASSWORD_ALGORITHM +
+                            "}";
+
+                    MessageDigest messageDigest;
+                    try {
+                        messageDigest = MessageDigest.getInstance(
+                                ConfigurationConstants.ADMIN_PASSWORD_ALGORITHM);
+                    } catch (NoSuchAlgorithmException e) {
+                        throw new Exception(
+                                "Could not find digest algorithm - " +
+                                        ConfigurationConstants.ADMIN_PASSWORD_ALGORITHM, e);
+                    }
+                    messageDigest.update(password.getBytes());
+                    byte[] bytes = messageDigest.digest();
+                    String hash = Base64.encode(bytes);
+                    passwordToStore = passwordToStore + hash;
+
+                    adminPrincipal.setUserPassword(passwordToStore.getBytes());
+
+                    EntryAttribute passwordAttribute = new DefaultServerAttribute(
+                            getAttributeType("userPassword"));
+                    passwordAttribute.add(passwordToStore.getBytes());
+
+                    ServerModification serverModification =
+                            new ServerModification(ModificationOperation.REPLACE_ATTRIBUTE,
+                                    passwordAttribute);
+
+                    List<Modification> modifiedList = new ArrayList<Modification>();
+                    modifiedList.add(serverModification);
+
+                    try {
+                        adminSession.modify(adminPrincipal.getClonedName(), modifiedList);
+                    } catch (Exception e) {
+                        String msg = "Failed changing connection user password.";
+                        log.error(msg, e);
+                        throw new Exception(msg, e);
+                    }
+
+                } else {
+                    String msg = "Could not retrieve admin principle. Failed changing connection " +
+                            "user password.";
+                    log.error(msg);
+                    throw new Exception(msg);
+                }
+            } else {
+                String msg = "Directory admin session is null. The LDAP server may not have " +
+                        "started yet.";
+                log.error(msg);
+                throw new Exception(msg);
+            }
+        } else {
+            String msg = "Directory service is null. The LDAP server may not have started yet.";
+            log.error(msg);
+            throw new Exception(msg);
+        }
+
+    }
+
+    private void configureDirectoryService()
+            throws Exception {
+
+        if (null == this.endPointConfigurations) {
+            throw new Exception("Directory service is not initialized.");
+        }
+
+        System.setProperty("workingDirectory", this.endPointConfigurations.getWorkingDirectory());
+
+        this.service.setShutdownHookEnabled(false);
+
+        this.service.setInstanceId(this.endPointConfigurations.getInstanceId());
+        this.service.setAllowAnonymousAccess(this.endPointConfigurations.isAllowAnonymousAccess());
+        this.service.setAccessControlEnabled(this.endPointConfigurations.isAccessControlOn());
+        this.service.setDenormalizeOpAttrsEnabled(
+                this.endPointConfigurations.isDeNormalizedAttributesEnabled());
+        this.service.setMaxPDUSize(this.endPointConfigurations.getMaxPDUSize());
+
+
+        // Add interceptors
+        List<Interceptor> list = this.service.getInterceptors();
+        // list.add(new KeyDerivationInterceptor());
+        list.add(0, new WSO2Interceptor());
+
+        this.service.setInterceptors(list);
+
+    }
+
+    protected void initializeLDAPServer()
+            throws Exception {
+
+        try {
+            if (null == this.service || null == this.endPointConfigurations) {
+                throw new Exception(
+                        "The default apacheds service is not initialized. " +
+                                "Make sure apacheds service is initialized first.");
+            }
+
+            this.ldapServer = new LdapServer();
+
+            this.ldapServer.setTransports(new TcpTransport(this.endPointConfigurations.getEndpointPort()));
+
+            // set server initial properties
+            this.ldapServer.setAllowAnonymousAccess(true);
+            this.ldapServer.setSaslHost(this.endPointConfigurations.getSaslHostName());
+            this.ldapServer.setSaslPrincipal(this.endPointConfigurations.getSaslPrincipalName());
+            this.ldapServer.setDirectoryService(this.service);
+
+            setupSaslMechanisms();
+
+        } catch (Exception e) {
+            throw new Exception("can not add the extension handlers ", e);
+        }
+    }
+
+    private void setupSaslMechanisms() {
+        mechanismHandlerMap = new HashMap<String, MechanismHandler>();
+
+        mechanismHandlerMap.put(SupportedSaslMechanisms.PLAIN, new PlainMechanismHandler());
+
+        CramMd5MechanismHandler cramMd5MechanismHandler = new CramMd5MechanismHandler();
+        mechanismHandlerMap.put(SupportedSaslMechanisms.CRAM_MD5, cramMd5MechanismHandler);
+
+        DigestMd5MechanismHandler digestMd5MechanismHandler = new DigestMd5MechanismHandler();
+        mechanismHandlerMap.put(SupportedSaslMechanisms.DIGEST_MD5, digestMd5MechanismHandler);
+
+        GssapiMechanismHandler gssapiMechanismHandler = new GssapiMechanismHandler();
+        mechanismHandlerMap.put(SupportedSaslMechanisms.GSSAPI, gssapiMechanismHandler);
+
+        NtlmMechanismHandler ntlmMechanismHandler = new NtlmMechanismHandler();
+
+        mechanismHandlerMap.put(SupportedSaslMechanisms.NTLM, ntlmMechanismHandler);
+        mechanismHandlerMap.put(SupportedSaslMechanisms.GSS_SPNEGO, ntlmMechanismHandler);
+
+        this.ldapServer.setSaslMechanismHandlers(mechanismHandlerMap);
+    }
+
+    /* This method we can use for the get ldapSession
+    public LdapSession[] getLdapSessions(){
+        return ldapServer.getLdapSessionManager().getSessions();
+    }*/
+
+}

--- a/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/impl/CarbonDirectoryServiceFactory.java
+++ b/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/impl/CarbonDirectoryServiceFactory.java
@@ -1,20 +1,17 @@
 /*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
- * Copyright (c) 2014, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
- *
- * WSO2 Inc. licenses this file to you under the Apache License,
- *  Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.wso2.carbon.identity.inbound.ldap.impl;
 

--- a/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/impl/CarbonDirectoryServiceFactory.java
+++ b/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/impl/CarbonDirectoryServiceFactory.java
@@ -95,8 +95,7 @@ class CarbonDirectoryServiceFactory implements DirectoryServiceFactory {
      * {@inheritDoc}
      */
     @Override
-    public void init(String name)
-            throws Exception {
+    public void init(String name) throws Exception {
 
         this.schemaZipStore = System.getProperty("schema.zip.store.location");
 
@@ -134,8 +133,7 @@ class CarbonDirectoryServiceFactory implements DirectoryServiceFactory {
      *
      * @throws Exception If unable to extract schema files.
      */
-    private void initSchema()
-            throws Exception {
+    private void initSchema() throws Exception {
         SchemaPartition schemaPartition = directoryService.getSchemaService().getSchemaPartition();
 
         // Init the LdifPartition
@@ -177,8 +175,7 @@ class CarbonDirectoryServiceFactory implements DirectoryServiceFactory {
      *
      * @throws Exception the exception
      */
-    private void initSystemPartition()
-            throws Exception {
+    private void initSystemPartition() throws Exception {
         // change the working apacheds to something that is unique
         // on the system and somewhere either under target apacheds
         // or somewhere in a temp area of the machine.
@@ -202,8 +199,7 @@ class CarbonDirectoryServiceFactory implements DirectoryServiceFactory {
      * @throws Exception In case if unable to extract schema or if an error occurred when building
      *                   the working directory.
      */
-    private void build(String name)
-            throws Exception {
+    private void build(String name) throws Exception {
         directoryService.setInstanceId(name);
         buildWorkingDirectory(name);
 
@@ -218,8 +214,7 @@ class CarbonDirectoryServiceFactory implements DirectoryServiceFactory {
      * {@inheritDoc}
      */
     @Override
-    public DirectoryService getDirectoryService()
-            throws Exception {
+    public DirectoryService getDirectoryService() throws Exception {
         return directoryService;
     }
 
@@ -227,8 +222,7 @@ class CarbonDirectoryServiceFactory implements DirectoryServiceFactory {
      * {@inheritDoc}
      */
     @Override
-    public PartitionFactory getPartitionFactory()
-            throws Exception {
+    public PartitionFactory getPartitionFactory() throws Exception {
         return partitionFactory;
     }
 

--- a/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/impl/CarbonDirectoryServiceFactory.java
+++ b/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/impl/CarbonDirectoryServiceFactory.java
@@ -65,8 +65,6 @@ class CarbonDirectoryServiceFactory implements DirectoryServiceFactory {
     private String schemaZipStore;
 
     /* default access */
-
-    @SuppressWarnings({"unchecked"})
     CarbonDirectoryServiceFactory() {
         try {
             // creating the instance here so that

--- a/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/impl/CarbonDirectoryServiceFactory.java
+++ b/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/impl/CarbonDirectoryServiceFactory.java
@@ -1,0 +1,240 @@
+/*
+ *
+ * Copyright (c) 2014, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.identity.inbound.ldap.impl;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.directory.server.constants.ServerDNConstants;
+import org.apache.directory.server.core.DefaultDirectoryService;
+import org.apache.directory.server.core.DirectoryService;
+import org.apache.directory.server.core.factory.DirectoryServiceFactory;
+import org.apache.directory.server.core.factory.JdbmPartitionFactory;
+import org.apache.directory.server.core.factory.PartitionFactory;
+import org.apache.directory.server.core.partition.Partition;
+import org.apache.directory.server.core.partition.ldif.LdifPartition;
+import org.apache.directory.server.core.schema.SchemaPartition;
+import org.apache.directory.server.i18n.I18n;
+import org.apache.directory.shared.ldap.constants.SchemaConstants;
+import org.apache.directory.shared.ldap.schema.SchemaManager;
+import org.apache.directory.shared.ldap.schema.ldif.extractor.SchemaLdifExtractor;
+import org.apache.directory.shared.ldap.schema.loader.ldif.LdifSchemaLoader;
+import org.apache.directory.shared.ldap.schema.manager.impl.DefaultSchemaManager;
+import org.apache.directory.shared.ldap.schema.registries.SchemaLoader;
+import org.apache.directory.shared.ldap.util.ExceptionUtils;
+
+import java.io.File;
+import java.util.List;
+
+class CarbonDirectoryServiceFactory implements DirectoryServiceFactory {
+
+    /**
+     * The default factory returns stock instances of a apacheds service with smart defaults
+     */
+    public static final DirectoryServiceFactory DEFAULT = new CarbonDirectoryServiceFactory();
+    /**
+     * A log for this class
+     */
+    private static final Log log = LogFactory.getLog(CarbonDirectoryServiceFactory.class);
+    /*Partition cache size is expressed as number of entries*/
+    private static final int PARTITION_CACHE_SIZE = 500;
+    private static final int INDEX_CACHE_SIZE = 100;
+    /**
+     * The apacheds service.
+     */
+    private DirectoryService directoryService;
+    /**
+     * The partition factory.
+     */
+    private PartitionFactory partitionFactory;
+    private String schemaZipStore;
+
+    /* default access */
+
+    @SuppressWarnings({"unchecked"})
+    CarbonDirectoryServiceFactory() {
+        try {
+            // creating the instance here so that
+            // we can set some properties like access control, anon access
+            // before starting up the service
+            directoryService = new DefaultDirectoryService();
+
+        } catch (Exception e) {
+            String errorMessage = "Error in initializing the default directory service.";
+            log.error(errorMessage);
+            throw new RuntimeException(errorMessage, e);
+        }
+
+        try {
+            String typeName = System.getProperty("apacheds.partition.factory");
+            if (typeName != null) {
+                Class<? extends PartitionFactory> type = (Class<? extends
+                        PartitionFactory>) Class.forName(typeName);
+                partitionFactory = type.newInstance();
+            } else {
+                partitionFactory = new JdbmPartitionFactory();
+            }
+        } catch (Exception e) {
+            String errorMessage = "Error instantiating custom partition factory";
+            log.error(errorMessage, e);
+            throw new RuntimeException(errorMessage, e);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void init(String name)
+            throws Exception {
+
+        this.schemaZipStore = System.getProperty("schema.zip.store.location");
+
+        if (this.schemaZipStore == null) {
+            throw new Exception(
+                    "Schema Jar repository is not set. Please set schema.jar.location property " +
+                            "with proper schema storage");
+        }
+
+        if (directoryService != null && directoryService.isStarted()) {
+            return;
+        }
+
+        build(name);
+    }
+
+    /**
+     * Build the working apacheds
+     *
+     * @param name Name of the working directory.
+     */
+    private void buildWorkingDirectory(String name) {
+        String workingDirectory = System.getProperty("workingDirectory");
+
+        if (workingDirectory == null) {
+            workingDirectory = System.getProperty("java.io.tmpdir") + File.separator +
+                    "server-work-" + name;
+        }
+
+        directoryService.setWorkingDirectory(new File(workingDirectory));
+    }
+
+    /**
+     * Inits the schema and schema partition.
+     *
+     * @throws Exception If unable to extract schema files.
+     */
+    private void initSchema()
+            throws Exception {
+        SchemaPartition schemaPartition = directoryService.getSchemaService().getSchemaPartition();
+
+        // Init the LdifPartition
+        LdifPartition ldifPartition = new LdifPartition();
+        String workingDirectory = directoryService.getWorkingDirectory().getPath();
+        ldifPartition.setWorkingDirectory(workingDirectory + File.separator + "schema");
+
+        // Extract the schema on disk (a brand new one) and load the registries
+        File schemaRepository = new File(workingDirectory, "schema");
+        if (!schemaRepository.exists()) {
+            SchemaLdifExtractor extractor =
+                    new CarbonSchemaLdifExtractor(new File(workingDirectory),
+                            new File(this.schemaZipStore));
+            extractor.extractOrCopy();
+        }
+
+        schemaPartition.setWrappedPartition(ldifPartition);
+
+        SchemaLoader loader = new LdifSchemaLoader(schemaRepository);
+        SchemaManager schemaManager = new DefaultSchemaManager(loader);
+        directoryService.setSchemaManager(schemaManager);
+
+        // We have to load the schema now, otherwise we won't be able
+        // to initialize the Partitions, as we won't be able to parse
+        // and normalize their suffix DN
+        schemaManager.loadAllEnabled();
+
+        schemaPartition.setSchemaManager(schemaManager);
+
+        List<Throwable> errors = schemaManager.getErrors();
+
+        if (!errors.isEmpty()) {
+            throw new Exception(I18n.err(I18n.ERR_317, ExceptionUtils.printErrors(errors)));
+        }
+    }
+
+    /**
+     * Inits the system partition.
+     *
+     * @throws Exception the exception
+     */
+    private void initSystemPartition()
+            throws Exception {
+        // change the working apacheds to something that is unique
+        // on the system and somewhere either under target apacheds
+        // or somewhere in a temp area of the machine.
+
+        // Inject the System Partition
+        Partition systemPartition = partitionFactory.createPartition(
+                "system", ServerDNConstants.SYSTEM_DN, PARTITION_CACHE_SIZE,
+                new File(directoryService.getWorkingDirectory(), "system"));
+        systemPartition.setSchemaManager(directoryService.getSchemaManager());
+
+        partitionFactory.addIndex(systemPartition, SchemaConstants.OBJECT_CLASS_AT,
+                INDEX_CACHE_SIZE);
+
+        directoryService.setSystemPartition(systemPartition);
+    }
+
+    /**
+     * Builds the apacheds server instance.
+     *
+     * @param name the instance name
+     * @throws Exception In case if unable to extract schema or if an error occurred when building
+     *                   the working directory.
+     */
+    private void build(String name)
+            throws Exception {
+        directoryService.setInstanceId(name);
+        buildWorkingDirectory(name);
+
+        // Init the service now
+        initSchema();
+        initSystemPartition();
+
+        directoryService.startup();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public DirectoryService getDirectoryService()
+            throws Exception {
+        return directoryService;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public PartitionFactory getPartitionFactory()
+            throws Exception {
+        return partitionFactory;
+    }
+
+}

--- a/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/impl/CarbonSchemaLdifExtractor.java
+++ b/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/impl/CarbonSchemaLdifExtractor.java
@@ -1,0 +1,190 @@
+/*
+ *
+ * Copyright (c) 2014, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.inbound.ldap.impl;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.directory.shared.ldap.schema.ldif.extractor.SchemaLdifExtractor;
+import org.wso2.carbon.identity.inbound.ldap.utils.IdentityIOStreamUtils;
+import org.wso2.carbon.identity.inbound.ldap.utils.IdentityLdapException;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+/**
+ * This is a schema ldif file extractor. Given a zip file of schemas, following class will unzip
+ * schemas to a folder called "schema" under working directory.
+ */
+
+class CarbonSchemaLdifExtractor implements SchemaLdifExtractor {
+
+    private static final String SCHEMA_SUB_DIR = "schema";
+
+    private static final Log log = LogFactory.getLog(CarbonSchemaLdifExtractor.class);
+
+    private boolean extracted;
+
+    private File schemaDirectory;
+
+    private File zipSchemaStore;
+
+    /**
+     * This will instantiate a Schema extractor.
+     *
+     * @param outputDirectory The directory which LDIF files will be extracted to.
+     * @param zipSchemaStore  A zip file containing all default LDIF schema files.
+     */
+    public CarbonSchemaLdifExtractor(File outputDirectory, File zipSchemaStore) {
+
+        this.zipSchemaStore = zipSchemaStore;
+        this.schemaDirectory = new File(outputDirectory, SCHEMA_SUB_DIR);
+
+        if (!outputDirectory.exists()) {
+            log.debug(String.format("Creating output directory: %s", outputDirectory));
+            if (!outputDirectory.mkdir()) {
+                log.error(String.format("Failed to create outputDirectory: %s",
+                        outputDirectory));
+            }
+        } else {
+            log.debug("Output directory exists: no need to create.");
+        }
+
+        if (!schemaDirectory.exists()) {
+            if (log.isDebugEnabled()) {
+                log.debug(String.format("Schema directory '%s' does NOT exist: extracted state " +
+                        "set to false.", schemaDirectory));
+            }
+
+            extracted = false;
+        } else {
+            if (log.isDebugEnabled()) {
+                log.debug(String.format("Schema directory '%s' does exist: extracted state set to " +
+                        "true.", schemaDirectory));
+            }
+
+            extracted = true;
+        }
+
+    }
+
+    @Override
+    public boolean isExtracted() {
+        return extracted;
+    }
+
+    @Override
+    public void extractOrCopy(boolean overwrite)
+            throws IOException {
+
+        if (schemaDirectory.exists() && overwrite) {
+            // remove the existing schema directory
+            FileUtils.deleteDirectory(schemaDirectory);
+        }
+
+        if (!schemaDirectory.exists() && !schemaDirectory.mkdir()) {
+            throw new IOException("Unable to create schema directory " +
+                    schemaDirectory.getAbsolutePath());
+        }
+
+        if (!this.zipSchemaStore.exists()) {
+            String msg = "Did not find LDAP schema files in " +
+                    this.zipSchemaStore.getAbsolutePath();
+            log.error(msg);
+            throw new IOException(msg);
+        }
+
+        try {
+            unzipSchemaFile();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
+        extracted = true;
+    }
+
+    protected void unzipSchemaFile()
+            throws IOException, IdentityLdapException {
+        ZipInputStream zipFileStream = null;
+
+        try {
+            FileInputStream schemaFileStream = new FileInputStream(this.zipSchemaStore);
+            zipFileStream = new ZipInputStream(new BufferedInputStream(schemaFileStream));
+            ZipEntry entry;
+
+            String basePath = this.schemaDirectory.getAbsolutePath();
+
+            while ((entry = zipFileStream.getNextEntry()) != null) {
+
+                if (entry.isDirectory()) {
+                    File newDirectory = new File(basePath, entry.getName());
+                    if (!newDirectory.mkdir()) {
+                        throw new IOException("Unable to create directory - " +
+                                newDirectory.getAbsolutePath());
+                    }
+                    continue;
+                }
+
+                int size;
+                byte[] buffer = new byte[2048];
+
+                FileOutputStream extractedSchemaFile = new FileOutputStream(
+                        new File(basePath, entry.getName()));
+                BufferedOutputStream extractingBufferedStream =
+                        new BufferedOutputStream(extractedSchemaFile, buffer.length);
+                try {
+                    while ((size = zipFileStream.read(buffer, 0, buffer.length)) != -1) {
+                        extractingBufferedStream.write(buffer, 0, size);
+                    }
+                } finally {
+                    IdentityIOStreamUtils.flushOutputStream(extractingBufferedStream);
+                    IdentityIOStreamUtils.closeOutputStream(extractingBufferedStream);
+                }
+            }
+        } catch (IOException e) {
+            String msg = "Unable to extract schema directory to location " +
+                    this.schemaDirectory.getAbsolutePath() + " from " +
+                    this.zipSchemaStore.getAbsolutePath();
+            log.error(msg, e);
+            throw new IOException(msg, e);
+        } finally {
+            IdentityIOStreamUtils.closeInputStream(zipFileStream);
+        }
+
+        if (log.isDebugEnabled()) {
+            log.debug("Successfully extracted schema files to path " +
+                    this.schemaDirectory.getAbsolutePath() + " using schema zip file " +
+                    this.zipSchemaStore.getAbsolutePath());
+        }
+
+    }
+
+    @Override
+    public void extractOrCopy()
+            throws IOException {
+        extractOrCopy(false);
+    }
+}

--- a/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/impl/CarbonSchemaLdifExtractor.java
+++ b/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/impl/CarbonSchemaLdifExtractor.java
@@ -1,20 +1,17 @@
 /*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
- * Copyright (c) 2014, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
- *
- * WSO2 Inc. licenses this file to you under the Apache License,
- *  Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.wso2.carbon.identity.inbound.ldap.impl;

--- a/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/impl/CarbonSchemaLdifExtractor.java
+++ b/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/impl/CarbonSchemaLdifExtractor.java
@@ -36,7 +36,6 @@ import java.util.zip.ZipInputStream;
  * This is a schema ldif file extractor. Given a zip file of schemas, following class will unzip
  * schemas to a folder called "schema" under working directory.
  */
-
 class CarbonSchemaLdifExtractor implements SchemaLdifExtractor {
 
     private static final String SCHEMA_SUB_DIR = "schema";
@@ -94,8 +93,7 @@ class CarbonSchemaLdifExtractor implements SchemaLdifExtractor {
     }
 
     @Override
-    public void extractOrCopy(boolean overwrite)
-            throws IOException {
+    public void extractOrCopy(boolean overwrite) throws IOException {
 
         if (schemaDirectory.exists() && overwrite) {
             // remove the existing schema directory
@@ -117,14 +115,13 @@ class CarbonSchemaLdifExtractor implements SchemaLdifExtractor {
         try {
             unzipSchemaFile();
         } catch (Exception e) {
-            e.printStackTrace();
+            throw new IOException("Can't unzip schema file", e);
         }
 
         extracted = true;
     }
 
-    protected void unzipSchemaFile()
-            throws IOException, IdentityLdapException {
+    protected void unzipSchemaFile() throws IOException, IdentityLdapException {
         ZipInputStream zipFileStream = null;
 
         try {
@@ -180,8 +177,7 @@ class CarbonSchemaLdifExtractor implements SchemaLdifExtractor {
     }
 
     @Override
-    public void extractOrCopy()
-            throws IOException {
+    public void extractOrCopy() throws IOException {
         extractOrCopy(false);
     }
 }

--- a/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/impl/ConfigurationConstants.java
+++ b/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/impl/ConfigurationConstants.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.carbon.identity.inbound.ldap.impl;
+
+/**
+ * Class which encapsulates, most of the configuration parameters used in apacheds implementation.
+ */
+public class ConfigurationConstants {
+
+    public static final String ADMIN_PASSWORD_ALGORITHM = "SHA";
+
+    private ConfigurationConstants() {
+    }
+}

--- a/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/impl/EndPointConfiguration.java
+++ b/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/impl/EndPointConfiguration.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.carbon.identity.inbound.ldap.impl;
+
+public class EndPointConfiguration {
+
+    private final static String DEFAULT_INSTANCE_ID = "default";
+
+    /**
+     * LDAP server specific configurations
+     */
+    private boolean enable;
+
+    private int ldapPort;
+
+    private String workingDirectory;
+
+    private boolean allowAnonymousAccess;
+
+    private boolean accessControlOn;
+
+    private boolean deNormalizedAttributesEnabled;
+
+    private int maxPDUSize;
+
+    /**
+     * Instance specific configurations
+     */
+
+    private String instanceId = DEFAULT_INSTANCE_ID;
+
+    private String saslHostName;
+
+    private String saslPrincipalName;
+
+    public EndPointConfiguration() {
+    }
+
+    public boolean isAllowAnonymousAccess() {
+        return allowAnonymousAccess;
+    }
+
+    public void setAllowAnonymousAccess(boolean allowAnonymousAccess) {
+        this.allowAnonymousAccess = allowAnonymousAccess;
+    }
+
+    public boolean isEnable() {
+        return enable;
+    }
+
+    public void setEnable(boolean enable) {
+        this.enable = enable;
+    }
+
+    public boolean isAccessControlOn() {
+        return accessControlOn;
+    }
+
+    public void setAccessControlOn(boolean accessControlOn) {
+        this.accessControlOn = accessControlOn;
+    }
+
+    public boolean isDeNormalizedAttributesEnabled() {
+        return deNormalizedAttributesEnabled;
+    }
+
+    public void setDeNormalizedAttributesEnabled(boolean deNormalizedAttributesEnabled) {
+        this.deNormalizedAttributesEnabled = deNormalizedAttributesEnabled;
+    }
+
+    public int getMaxPDUSize() {
+        return maxPDUSize;
+    }
+
+    public void setMaxPDUSize(int maxPDUSize) {
+        if (maxPDUSize == -1) {
+            return;
+        }
+        this.maxPDUSize = maxPDUSize;
+    }
+
+    public String getSaslHostName() {
+        return saslHostName;
+    }
+
+    public void setSaslHostName(String saslHostName) {
+        if (saslHostName == null) {
+            return;
+        }
+
+        this.saslHostName = saslHostName;
+    }
+
+    public String getSaslPrincipalName() {
+        return saslPrincipalName;
+    }
+
+    public void setSaslPrincipalName(String saslPrincipalName) {
+        if (saslPrincipalName == null) {
+            return;
+        }
+
+        this.saslPrincipalName = saslPrincipalName;
+    }
+
+    public String getInstanceId() {
+        return instanceId;
+    }
+
+    public void setInstanceId(String instanceId) {
+        if (instanceId == null) {
+            return;
+        }
+
+        this.instanceId = instanceId;
+    }
+
+    public int getEndpointPort() {
+        return ldapPort;
+    }
+
+    public void setEndpointPort(int ldapPort) {
+        if (ldapPort == -1) {
+            return;
+        }
+
+        this.ldapPort = ldapPort;
+    }
+
+    public String getWorkingDirectory() {
+        return workingDirectory;
+    }
+
+    public void setWorkingDirectory(String workingDirectory) {
+        if (workingDirectory == null) {
+            return;
+        }
+
+        this.workingDirectory = workingDirectory;
+    }
+}

--- a/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/impl/EndPointConfiguration.java
+++ b/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/impl/EndPointConfiguration.java
@@ -101,7 +101,6 @@ public class EndPointConfiguration {
         if (saslHostName == null) {
             return;
         }
-
         this.saslHostName = saslHostName;
     }
 
@@ -113,7 +112,6 @@ public class EndPointConfiguration {
         if (saslPrincipalName == null) {
             return;
         }
-
         this.saslPrincipalName = saslPrincipalName;
     }
 
@@ -125,7 +123,6 @@ public class EndPointConfiguration {
         if (instanceId == null) {
             return;
         }
-
         this.instanceId = instanceId;
     }
 
@@ -137,7 +134,6 @@ public class EndPointConfiguration {
         if (ldapPort == -1) {
             return;
         }
-
         this.ldapPort = ldapPort;
     }
 
@@ -149,7 +145,6 @@ public class EndPointConfiguration {
         if (workingDirectory == null) {
             return;
         }
-
         this.workingDirectory = workingDirectory;
     }
 }

--- a/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/impl/EndPointConfiguration.java
+++ b/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/impl/EndPointConfiguration.java
@@ -16,6 +16,9 @@
 
 package org.wso2.carbon.identity.inbound.ldap.impl;
 
+/**
+ * This class has been use for the set ldap configuration.
+ */
 public class EndPointConfiguration {
 
     private final static String DEFAULT_INSTANCE_ID = "default";

--- a/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/impl/LDAPServer.java
+++ b/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/impl/LDAPServer.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.carbon.identity.inbound.ldap.impl;
+
+/**
+ * Represents a LDAP server.
+ */
+public interface LDAPServer {
+
+    /**
+     * Initializes directory service. Will create a LDAP server instance using apacheeds
+     * APIs.
+     */
+    void init(EndPointConfiguration configurations) throws Exception;
+
+    /**
+     * Will start LDAP server. Must be initialized first.
+     */
+    void start() throws Exception;
+
+    /**
+     * Stopes the LDAP server.
+     */
+    void stop() throws Exception;
+
+    /**
+     * Changes the connection user password. As for now we don't allow users to change admin domain
+     * name.
+     * But users can change admin's password using this method.
+     *
+     * @param password New password.
+     */
+    void changeConnectionUserPassword(String password)
+            throws Exception;
+
+    /**
+     * Gets system admins connection domain name.
+     * Ex :- uid=admin,ou=system
+     *
+     * @return Admin's domain name as a domain name entry.
+     */
+    String getConnectionDomainName() throws Exception;
+
+}

--- a/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/impl/WSO2UserManager.java
+++ b/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/impl/WSO2UserManager.java
@@ -35,12 +35,12 @@ public class WSO2UserManager {
 
     public void addUser(AddOperationContext addOperationContext) throws IdentityLdapException {
         try {
-            ldapUserManager = identityLDAPManager.getUserManager("admin");
             Entry entry = addOperationContext.getEntry();
             LDAPUser ldapUser = new LDAPUser();
             ldapUser.setUsername(entry.get(LDAPConstants.LDAPSchemaConstants.USERNAME).get().getString());
             ldapUser.setPassword(entry.get(LDAPConstants.LDAPSchemaConstants.PASSWORD).get().getString());
             ldapUser.setUserAttributes(entry);
+            ldapUserManager = identityLDAPManager.getUserManager();
             ldapUserManager.createUser(ldapUser);
         } catch (Exception ex) {
             String msg = "An error occurred while performing add operation";
@@ -50,9 +50,9 @@ public class WSO2UserManager {
 
     public void deleteUser(DeleteOperationContext deleteOperationContext) throws IdentityLdapException {
         try {
-            ldapUserManager = identityLDAPManager.getUserManager("admin");
             String dn = deleteOperationContext.getDn().toString();
             String username = getDeleteUsername(dn);
+            ldapUserManager = identityLDAPManager.getUserManager();
             ldapUserManager.deleteUser(username);
         } catch (Exception ex) {
             String msg = "An error occurred while performing delete operation";

--- a/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/impl/WSO2UserManager.java
+++ b/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/impl/WSO2UserManager.java
@@ -29,7 +29,6 @@ import org.wso2.carbon.identity.inbound.ldap.utils.IdentityLdapException;
 
 public class WSO2UserManager {
 
-
     private static final Log log = LogFactory.getLog(WSO2UserManager.class);
     private LDAPUserManager ldapUserManager = null;
     private IdentityLDAPManager identityLDAPManager = new IdentityLDAPManager();
@@ -46,9 +45,7 @@ public class WSO2UserManager {
         } catch (Exception ex) {
             String msg = "An error occurred while performing add operation";
             throw new IdentityLdapException(msg, ex);
-
         }
-
     }
 
     public void deleteUser(DeleteOperationContext deleteOperationContext) throws IdentityLdapException {
@@ -61,7 +58,6 @@ public class WSO2UserManager {
             String msg = "An error occurred while performing delete operation";
             throw new IdentityLdapException(msg, ex);
         }
-
     }
 
     private String getDeleteUsername(String dn) {
@@ -70,7 +66,6 @@ public class WSO2UserManager {
         if (splitDn != null) {
             uid = splitDn[0].split("=");
         }
-
         return uid[1];
     }
 

--- a/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/impl/WSO2UserManager.java
+++ b/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/impl/WSO2UserManager.java
@@ -27,6 +27,9 @@ import org.wso2.carbon.identity.inbound.ldap.provider.LDAPUser;
 import org.wso2.carbon.identity.inbound.ldap.provider.LDAPUserManager;
 import org.wso2.carbon.identity.inbound.ldap.utils.IdentityLdapException;
 
+/**
+ * This class has been use for the manage ldap users when it comes to interceptor level.
+ */
 public class WSO2UserManager {
 
     private static final Log log = LogFactory.getLog(WSO2UserManager.class);

--- a/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/impl/WSO2UserManager.java
+++ b/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/impl/WSO2UserManager.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.carbon.identity.inbound.ldap.impl;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.directory.server.core.interceptor.context.AddOperationContext;
+import org.apache.directory.server.core.interceptor.context.DeleteOperationContext;
+import org.apache.directory.shared.ldap.entry.Entry;
+import org.wso2.carbon.identity.inbound.ldap.provider.IdentityLDAPManager;
+import org.wso2.carbon.identity.inbound.ldap.provider.LDAPConstants;
+import org.wso2.carbon.identity.inbound.ldap.provider.LDAPUser;
+import org.wso2.carbon.identity.inbound.ldap.provider.LDAPUserManager;
+import org.wso2.carbon.identity.inbound.ldap.utils.IdentityLdapException;
+
+public class WSO2UserManager {
+
+
+    private static final Log log = LogFactory.getLog(WSO2UserManager.class);
+    private LDAPUserManager ldapUserManager = null;
+    private IdentityLDAPManager identityLDAPManager = new IdentityLDAPManager();
+
+    public void addUser(AddOperationContext addOperationContext) throws IdentityLdapException {
+        try {
+            ldapUserManager = identityLDAPManager.getUserManager("admin");
+            Entry entry = addOperationContext.getEntry();
+            LDAPUser ldapUser = new LDAPUser();
+            ldapUser.setUsername(entry.get(LDAPConstants.LDAPSchemaConstants.USERNAME).get().getString());
+            ldapUser.setPassword(entry.get(LDAPConstants.LDAPSchemaConstants.PASSWORD).get().getString());
+            ldapUser.setUserAttributes(entry);
+            ldapUserManager.createUser(ldapUser);
+        } catch (Exception ex) {
+            String msg = "An error occurred while performing add operation";
+            throw new IdentityLdapException(msg, ex);
+
+        }
+
+    }
+
+    public void deleteUser(DeleteOperationContext deleteOperationContext) throws IdentityLdapException {
+        try {
+            ldapUserManager = identityLDAPManager.getUserManager("admin");
+            String dn = deleteOperationContext.getDn().toString();
+            String username = getDeleteUsername(dn);
+            ldapUserManager.deleteUser(username);
+        } catch (Exception ex) {
+            String msg = "An error occurred while performing delete operation";
+            throw new IdentityLdapException(msg, ex);
+        }
+
+    }
+
+    private String getDeleteUsername(String dn) {
+        String[] splitDn = dn.split(",");
+        String[] uid = null;
+        if (splitDn != null) {
+            uid = splitDn[0].split("=");
+        }
+
+        return uid[1];
+    }
+
+}

--- a/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/interceptor/WSO2Interceptor.java
+++ b/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/interceptor/WSO2Interceptor.java
@@ -28,6 +28,10 @@ import org.apache.directory.server.core.interceptor.context.ModifyOperationConte
 import org.apache.directory.server.core.interceptor.context.SearchOperationContext;
 import org.wso2.carbon.identity.inbound.ldap.impl.WSO2UserManager;
 
+/**
+ * This is the interceptor class. Which has been use for the capture ldap message content. Ldap message content has
+ * been pass with opContext parameter.
+ */
 public class WSO2Interceptor extends BaseInterceptor {
 
     private static final Log log = LogFactory.getLog(WSO2Interceptor.class);
@@ -43,15 +47,12 @@ public class WSO2Interceptor extends BaseInterceptor {
         } catch (Exception e) {
             String msg = "Error occur in AddOperationContext";
             log.error(msg, e);
+            throw new Exception(msg);
         }
     }
 
     public EntryFilteringCursor search(NextInterceptor next, SearchOperationContext opContext) throws Exception {
         return null;
-    }
-
-    public void modify(NextInterceptor next, ModifyOperationContext opContext) throws Exception {
-
     }
 
     public void delete(NextInterceptor next, DeleteOperationContext opContext) throws Exception {
@@ -61,6 +62,7 @@ public class WSO2Interceptor extends BaseInterceptor {
         } catch (Exception e) {
             String msg = "Error occur in DeleteOperationContext";
             log.error(msg, e);
+            throw new Exception(msg);
         }
     }
 

--- a/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/interceptor/WSO2Interceptor.java
+++ b/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/interceptor/WSO2Interceptor.java
@@ -42,16 +42,10 @@ public class WSO2Interceptor extends BaseInterceptor {
             opContext.getSession();
             WSO2UserManager wso2UserManager = new WSO2UserManager();
             wso2UserManager.addUser(opContext);
-
-            // Here ldapSession we use for the write response message
-            // LdapSession[] ldapSessions=ApacheLDAPServer.getApacheLDAPServer().getLdapSessions();
-            // LdapSession ldapSession=ldapSessions[0];
-            // ldapSession.getIoSession().write(msg);
         } catch (Exception e) {
             String msg = "Error occur in AddOperationContext";
             log.error(msg, e);
         }
-
     }
 
     public EntryFilteringCursor search(NextInterceptor next, SearchOperationContext opContext) throws Exception {
@@ -70,8 +64,6 @@ public class WSO2Interceptor extends BaseInterceptor {
             String msg = "Error occur in DeleteOperationContext";
             log.error(msg, e);
         }
-
-
     }
 
 }

--- a/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/interceptor/WSO2Interceptor.java
+++ b/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/interceptor/WSO2Interceptor.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.carbon.identity.inbound.ldap.interceptor;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.directory.server.core.DirectoryService;
+import org.apache.directory.server.core.filtering.EntryFilteringCursor;
+import org.apache.directory.server.core.interceptor.BaseInterceptor;
+import org.apache.directory.server.core.interceptor.NextInterceptor;
+import org.apache.directory.server.core.interceptor.context.AddOperationContext;
+import org.apache.directory.server.core.interceptor.context.DeleteOperationContext;
+import org.apache.directory.server.core.interceptor.context.ModifyOperationContext;
+import org.apache.directory.server.core.interceptor.context.SearchOperationContext;
+import org.wso2.carbon.identity.inbound.ldap.impl.WSO2UserManager;
+
+public class WSO2Interceptor extends BaseInterceptor {
+
+    private static final Log log = LogFactory.getLog(WSO2Interceptor.class);
+
+    public void init(DirectoryService directoryService) throws Exception {
+        log.info("WSO2Interceptor initialize sucessfully");
+    }
+
+    public void add(NextInterceptor next, AddOperationContext opContext) throws Exception {
+        try {
+            opContext.getName();
+            opContext.getSession();
+            WSO2UserManager wso2UserManager = new WSO2UserManager();
+            wso2UserManager.addUser(opContext);
+
+            // Here ldapSession we use for the write response message
+            // LdapSession[] ldapSessions=ApacheLDAPServer.getApacheLDAPServer().getLdapSessions();
+            // LdapSession ldapSession=ldapSessions[0];
+            // ldapSession.getIoSession().write(msg);
+        } catch (Exception e) {
+            String msg = "Error occur in AddOperationContext";
+            log.error(msg, e);
+        }
+
+    }
+
+    public EntryFilteringCursor search(NextInterceptor next, SearchOperationContext opContext) throws Exception {
+        return null;
+    }
+
+    public void modify(NextInterceptor next, ModifyOperationContext opContext) throws Exception {
+
+    }
+
+    public void delete(NextInterceptor next, DeleteOperationContext opContext) throws Exception {
+        try {
+            WSO2UserManager wso2UserManager = new WSO2UserManager();
+            wso2UserManager.deleteUser(opContext);
+        } catch (Exception e) {
+            String msg = "Error occur in DeleteOperationContext";
+            log.error(msg, e);
+        }
+
+
+    }
+
+}

--- a/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/interceptor/WSO2Interceptor.java
+++ b/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/interceptor/WSO2Interceptor.java
@@ -38,8 +38,6 @@ public class WSO2Interceptor extends BaseInterceptor {
 
     public void add(NextInterceptor next, AddOperationContext opContext) throws Exception {
         try {
-            opContext.getName();
-            opContext.getSession();
             WSO2UserManager wso2UserManager = new WSO2UserManager();
             wso2UserManager.addUser(opContext);
         } catch (Exception e) {

--- a/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/interceptor/WSO2Interceptor.java
+++ b/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/interceptor/WSO2Interceptor.java
@@ -24,7 +24,6 @@ import org.apache.directory.server.core.interceptor.BaseInterceptor;
 import org.apache.directory.server.core.interceptor.NextInterceptor;
 import org.apache.directory.server.core.interceptor.context.AddOperationContext;
 import org.apache.directory.server.core.interceptor.context.DeleteOperationContext;
-import org.apache.directory.server.core.interceptor.context.ModifyOperationContext;
 import org.apache.directory.server.core.interceptor.context.SearchOperationContext;
 import org.wso2.carbon.identity.inbound.ldap.impl.WSO2UserManager;
 

--- a/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/internal/LDAPEPComponent.java
+++ b/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/internal/LDAPEPComponent.java
@@ -28,7 +28,7 @@ import org.osgi.service.component.annotations.ReferencePolicy;
 import org.wso2.carbon.identity.inbound.ldap.impl.ApacheLDAPServer;
 import org.wso2.carbon.identity.inbound.ldap.impl.EndPointConfiguration;
 import org.wso2.carbon.identity.inbound.ldap.impl.LDAPServer;
-import org.wso2.carbon.identity.inbound.ldap.utils.ConfigurartionBuilder;
+import org.wso2.carbon.identity.inbound.ldap.utils.ConfigurationBuilder;
 import org.wso2.carbon.identity.inbound.ldap.utils.IdentityLdapException;
 import org.wso2.carbon.user.core.service.RealmService;
 
@@ -51,18 +51,18 @@ public class LDAPEPComponent {
 
             /*Read the ldap-org.wso2.carbon.identity.inbound.ldap.endpoint configuration file.*/
 
-            ConfigurartionBuilder configurartionBuilder = new ConfigurartionBuilder();
+            ConfigurationBuilder configurationBuilder = new ConfigurationBuilder();
 
-            configurartionBuilder.buildConfiguration(getLdapConfigurationFile());
+            configurationBuilder.buildConfiguration(getLdapConfigurationFile());
 
             /*Make relevant objects that encapsulate different parts of config file.*/
-            configurartionBuilder.buildLDAPEndpointConfigurartion();
+            configurationBuilder.buildLDAPEndpointConfigurartion();
 
-            boolean LdapEndpointEnabled = configurartionBuilder.isLdapEndpointEnabled();
+            boolean LdapEndpointEnabled = configurationBuilder.isLdapEndpointEnabled();
             //expose LDAP Endpoint only if ldap-org.wso2.carbon.identity.inbound.ldap.endpoint is enabled.
             if (LdapEndpointEnabled) {
 
-                EndPointConfiguration endPointConfiguration = configurartionBuilder.getEndPointConfiguration();
+                EndPointConfiguration endPointConfiguration = configurationBuilder.getEndPointConfiguration();
 
                 /*set the embedded-apacheds's schema location which is: carbon-home/repository/data/
                   is-default-schema.zip
@@ -75,7 +75,7 @@ public class LDAPEPComponent {
                 startLdapServer(endPointConfiguration);
 
                 /* replace default password with that is provided in the configuration file.*/
-                this.ldapServer.changeConnectionUserPassword(configurartionBuilder.getConnectionPassword());
+                this.ldapServer.changeConnectionUserPassword(configurationBuilder.getConnectionPassword());
 
 
                 if (log.isDebugEnabled()) {

--- a/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/internal/LDAPEPComponent.java
+++ b/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/internal/LDAPEPComponent.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.carbon.identity.inbound.ldap.internal;
+
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.wso2.carbon.identity.inbound.ldap.impl.ApacheLDAPServer;
+import org.wso2.carbon.identity.inbound.ldap.impl.EndPointConfiguration;
+import org.wso2.carbon.identity.inbound.ldap.impl.LDAPServer;
+import org.wso2.carbon.identity.inbound.ldap.utils.ConfigurartionBuilder;
+import org.wso2.carbon.identity.inbound.ldap.utils.IdentityLdapException;
+import org.wso2.carbon.user.core.service.RealmService;
+
+import java.io.File;
+
+
+@Component(
+        name = "org.wso2.carbon.identity.inbound.ldap.internal.LDAPEPComponent",
+        immediate = true)
+public class LDAPEPComponent {
+
+    private static final Log log = LogFactory.getLog(LDAPEPComponent.class);
+
+    private LDAPServer ldapServer;
+
+    @Activate
+    public void activate(ComponentContext context) {
+
+        try {
+
+            /*Read the ldap-org.wso2.carbon.identity.inbound.ldap.endpoint configuration file.*/
+
+            ConfigurartionBuilder configurartionBuilder = new ConfigurartionBuilder();
+
+            configurartionBuilder.buildConfiguration(getLdapConfigurationFile());
+
+            /*Make relevant objects that encapsulate different parts of config file.*/
+            configurartionBuilder.buildLDAPEndpointConfigurartion();
+
+            boolean LdapEndpointEnabled = configurartionBuilder.isLdapEndpointEnabled();
+            //expose LDAP Endpoint only if ldap-org.wso2.carbon.identity.inbound.ldap.endpoint is enabled.
+            if (LdapEndpointEnabled) {
+
+                EndPointConfiguration endPointConfiguration = configurartionBuilder.getEndPointConfiguration();
+
+                /*set the embedded-apacheds's schema location which is: carbon-home/repository/data/
+                  is-default-schema.zip
+                */
+                setSchemaLocation();
+
+                /* Set working directory where schema directory and ldap partitions are created*/
+                setWorkingDirectory(endPointConfiguration);
+
+                startLdapServer(endPointConfiguration);
+
+                /* replace default password with that is provided in the configuration file.*/
+                this.ldapServer.changeConnectionUserPassword(configurartionBuilder.getConnectionPassword());
+
+
+                if (log.isDebugEnabled()) {
+                    log.debug("apacheds-enpoint component started.");
+                }
+
+            } else if (!LdapEndpointEnabled) {
+                //if needed, create a dummy tenant manager service and register it.
+                log.info("LDAP Endpoint is disabled.");
+            }
+
+        } catch (Exception e) {
+            log.error("Could not start the ldap-org.wso2.carbon.identity.inbound.ldap.endpoint. ", e);
+        }
+
+    }
+
+    @Deactivate
+    public void deactivate(ComponentContext context)
+            throws Exception {
+        if (this.ldapServer != null) {
+
+            this.ldapServer.stop();
+        }
+    }
+
+    private void setSchemaLocation() throws Exception {
+        String schemaLocation = "repository" + File.separator + "data" + File.separator +
+                "is-default-schema.zip";
+        File dataDir = new File(getCarbonHome(), schemaLocation);
+
+        // Set schema location
+        System.setProperty("schema.zip.store.location", dataDir.getAbsolutePath());
+    }
+
+    private String getCarbonHome() throws Exception {
+        String carbonHome = System.getProperty("carbon.home");
+        if (carbonHome == null) {
+            String msg = "carbon.home property not set. Cannot find carbon home directory.";
+            log.error(msg);
+            throw new IdentityLdapException(msg);
+        }
+
+        return carbonHome;
+    }
+
+    private File getLdapConfigurationFile() throws Exception {
+
+        String configurationFilePath = "repository" + File.separator + "conf" + File.separator + "identity"
+                + File.separator + "identity.xml";
+        return new File(getCarbonHome(), configurationFilePath);
+    }
+
+    private void setWorkingDirectory(EndPointConfiguration endPointConfiguration)
+            throws Exception {
+
+        if (".".equals(endPointConfiguration.getWorkingDirectory())) {
+            File dataDir = new File(getCarbonHome(), "repository/data");
+            if (!dataDir.exists() && !dataDir.mkdir()) {
+                String msg = "Unable to create data directory at " + dataDir.getAbsolutePath();
+                log.error(msg);
+                throw new IdentityLdapException(msg);
+            }
+
+            File bundleDataDir = new File(dataDir, "org.wso2.carbon.directory");
+            if (!bundleDataDir.exists() && !bundleDataDir.mkdirs()) {
+                String msg = "Unable to create schema data directory at " + bundleDataDir.
+                        getAbsolutePath();
+                log.error(msg);
+                throw new IdentityLdapException(msg);
+
+
+            }
+
+            endPointConfiguration.setWorkingDirectory(bundleDataDir.getAbsolutePath());
+        }
+    }
+
+    private void startLdapServer(EndPointConfiguration endPointConfiguration)
+            throws Exception {
+
+        this.ldapServer = ApacheLDAPServer.getApacheLDAPServer();
+
+        if (log.isDebugEnabled()) {
+            log.debug("Initializing Directory Server with working directory " + endPointConfiguration.
+                    getWorkingDirectory() + " and port " + endPointConfiguration.getEndpointPort());
+        }
+
+        this.ldapServer.init(endPointConfiguration);
+
+        this.ldapServer.start();
+    }
+
+
+    @Reference(
+            name = "user.realmservice.default",
+            service = RealmService.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetRealmService")
+    protected void setRealmService(RealmService realmService) {
+
+        if (log.isDebugEnabled()) {
+            log.debug("realmService set in LDAPEndPointCommonComponent bundle");
+        }
+        LDAPEPComponentHolder.setRealmService(realmService);
+    }
+
+    /**
+     * Unset realm service implementation
+     */
+    protected void unsetRealmService(RealmService realmService) {
+
+        if (log.isDebugEnabled()) {
+            log.debug("realmService unset in  LDAPEndPointComponent bundle");
+        }
+        LDAPEPComponentHolder.setRealmService(null);
+    }
+
+}

--- a/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/internal/LDAPEPComponent.java
+++ b/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/internal/LDAPEPComponent.java
@@ -43,6 +43,7 @@ public class LDAPEPComponent {
     private static final Log log = LogFactory.getLog(LDAPEPComponent.class);
 
     private LDAPServer ldapServer;
+    private static final String APACHEDS_SCHEMA_LOCATION= "apacheds.schema.zip.store.location";
 
     @Activate
     public void activate(ComponentContext context) {
@@ -108,7 +109,7 @@ public class LDAPEPComponent {
         File dataDir = new File(getCarbonHome(), schemaLocation);
 
         // Set schema location
-        System.setProperty("schema.zip.store.location", dataDir.getAbsolutePath());
+        System.setProperty(APACHEDS_SCHEMA_LOCATION, dataDir.getAbsolutePath());
     }
 
     private String getCarbonHome() throws Exception {
@@ -129,8 +130,7 @@ public class LDAPEPComponent {
         return new File(getCarbonHome(), configurationFilePath);
     }
 
-    private void setWorkingDirectory(EndPointConfiguration endPointConfiguration)
-            throws Exception {
+    private void setWorkingDirectory(EndPointConfiguration endPointConfiguration) throws Exception {
 
         if (".".equals(endPointConfiguration.getWorkingDirectory())) {
             File dataDir = new File(getCarbonHome(), "repository/data");
@@ -154,8 +154,7 @@ public class LDAPEPComponent {
         }
     }
 
-    private void startLdapServer(EndPointConfiguration endPointConfiguration)
-            throws Exception {
+    private void startLdapServer(EndPointConfiguration endPointConfiguration) throws Exception {
 
         this.ldapServer = ApacheLDAPServer.getApacheLDAPServer();
 

--- a/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/internal/LDAPEPComponent.java
+++ b/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/internal/LDAPEPComponent.java
@@ -16,7 +16,6 @@
 
 package org.wso2.carbon.identity.inbound.ldap.internal;
 
-
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.osgi.service.component.ComponentContext;
@@ -169,7 +168,6 @@ public class LDAPEPComponent {
 
         this.ldapServer.start();
     }
-
 
     @Reference(
             name = "user.realmservice.default",

--- a/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/internal/LDAPEPComponent.java
+++ b/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/internal/LDAPEPComponent.java
@@ -41,9 +41,8 @@ import java.io.File;
 public class LDAPEPComponent {
 
     private static final Log log = LogFactory.getLog(LDAPEPComponent.class);
-
+    private static final String APACHEDS_SCHEMA_LOCATION = "apacheds.schema.zip.store.location";
     private LDAPServer ldapServer;
-    private static final String APACHEDS_SCHEMA_LOCATION= "apacheds.schema.zip.store.location";
 
     @Activate
     public void activate(ComponentContext context) {

--- a/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/internal/LDAPEPComponentHolder.java
+++ b/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/internal/LDAPEPComponentHolder.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.carbon.identity.inbound.ldap.internal;
+
+import org.wso2.carbon.user.core.service.RealmService;
+
+public class LDAPEPComponentHolder {
+
+    private static RealmService realmService;
+
+
+    public static RealmService getRealmService() {
+
+        return LDAPEPComponentHolder.realmService;
+    }
+
+    /**
+     * Set realm service.
+     *
+     * @param realmService
+     */
+    public static void setRealmService(RealmService realmService) {
+
+        LDAPEPComponentHolder.realmService = realmService;
+    }
+}

--- a/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/provider/IdentityLDAPManager.java
+++ b/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/provider/IdentityLDAPManager.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.carbon.identity.inbound.ldap.provider;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.carbon.identity.inbound.ldap.internal.LDAPEPComponentHolder;
+import org.wso2.carbon.identity.inbound.ldap.utils.IdentityLdapException;
+import org.wso2.carbon.user.api.UserRealm;
+import org.wso2.carbon.user.core.UserStoreManager;
+import org.wso2.carbon.user.core.claim.ClaimManager;
+import org.wso2.carbon.user.core.service.RealmService;
+import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
+
+public class IdentityLDAPManager {
+
+    private static final Log log = LogFactory.getLog(IdentityLDAPManager.class);
+
+
+    public LDAPUserManager getUserManager(String username) throws Exception {
+        LDAPUserManager ldapUserManager = null;
+        String tenantDomain = MultitenantUtils.getTenantDomain(username);
+        String tenantLessUserName = MultitenantUtils.getTenantAwareUsername(username);
+
+        try {
+
+            //get super tenant context and get relam service which is an osgi service
+            RealmService realmService = LDAPEPComponentHolder.getRealmService();
+            if (realmService != null) {
+                int tenantId = realmService.getTenantManager().getTenantId(tenantDomain);
+
+                //get tenant's user realm
+                UserRealm userRealm = realmService.getTenantUserRealm(tenantId);
+                ClaimManager claimManager;
+                if (userRealm != null) {
+                    //get claim manager for manipulating attributes
+                    claimManager = (ClaimManager) userRealm.getClaimManager();
+
+
+                    String authenticatedUser = PrivilegedCarbonContext.getThreadLocalCarbonContext().getUsername();
+                    if (authenticatedUser == null) {
+                        PrivilegedCarbonContext.getThreadLocalCarbonContext().setUsername(tenantLessUserName);
+                        if (log.isDebugEnabled()) {
+                            log.debug("User read from carbon context is null, hence setting " +
+                                    "authenticated user: " + tenantLessUserName);
+                        }
+                    }
+
+                    ldapUserManager = new LDAPUserManager((UserStoreManager) userRealm.getUserStoreManager(), username, claimManager);
+                    // ldapUserManager.createUser();
+                }
+
+            }
+
+
+        } catch (Exception ex) {
+            throw new IdentityLdapException("Error occur while getting userstore manager", ex);
+        }
+
+        return ldapUserManager;
+    }
+}

--- a/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/provider/IdentityLDAPManager.java
+++ b/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/provider/IdentityLDAPManager.java
@@ -31,7 +31,7 @@ public class IdentityLDAPManager {
 
     private static final Log log = LogFactory.getLog(IdentityLDAPManager.class);
 
-    public LDAPUserManager getUserManager() throws Exception {
+    public LDAPUserManager getUserManager() throws IdentityLdapException {
         LDAPUserManager ldapUserManager = null;
         String username="carbon.super";
         String tenantDomain = MultitenantUtils.getTenantDomain(username);

--- a/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/provider/IdentityLDAPManager.java
+++ b/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/provider/IdentityLDAPManager.java
@@ -31,7 +31,6 @@ public class IdentityLDAPManager {
 
     private static final Log log = LogFactory.getLog(IdentityLDAPManager.class);
 
-
     public LDAPUserManager getUserManager(String username) throws Exception {
         LDAPUserManager ldapUserManager = null;
         String tenantDomain = MultitenantUtils.getTenantDomain(username);
@@ -51,7 +50,6 @@ public class IdentityLDAPManager {
                     //get claim manager for manipulating attributes
                     claimManager = (ClaimManager) userRealm.getClaimManager();
 
-
                     String authenticatedUser = PrivilegedCarbonContext.getThreadLocalCarbonContext().getUsername();
                     if (authenticatedUser == null) {
                         PrivilegedCarbonContext.getThreadLocalCarbonContext().setUsername(tenantLessUserName);
@@ -65,9 +63,7 @@ public class IdentityLDAPManager {
                             claimManager);
                     // ldapUserManager.createUser();
                 }
-
             }
-
 
         } catch (Exception ex) {
             throw new IdentityLdapException("Error occur while getting userstore manager", ex);

--- a/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/provider/IdentityLDAPManager.java
+++ b/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/provider/IdentityLDAPManager.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.carbon.identity.inbound.ldap.provider;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.carbon.identity.inbound.ldap.internal.LDAPEPComponentHolder;
+import org.wso2.carbon.identity.inbound.ldap.utils.IdentityLdapException;
+import org.wso2.carbon.user.api.UserRealm;
+import org.wso2.carbon.user.core.UserStoreManager;
+import org.wso2.carbon.user.core.claim.ClaimManager;
+import org.wso2.carbon.user.core.service.RealmService;
+import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
+
+public class IdentityLDAPManager {
+
+    private static final Log log = LogFactory.getLog(IdentityLDAPManager.class);
+
+
+    public LDAPUserManager getUserManager(String username) throws Exception {
+        LDAPUserManager ldapUserManager = null;
+        String tenantDomain = MultitenantUtils.getTenantDomain(username);
+        String tenantLessUserName = MultitenantUtils.getTenantAwareUsername(username);
+
+        try {
+
+            //get super tenant context and get relam service which is an osgi service
+            RealmService realmService = LDAPEPComponentHolder.getRealmService();
+            if (realmService != null) {
+                int tenantId = realmService.getTenantManager().getTenantId(tenantDomain);
+
+                //get tenant's user realm
+                UserRealm userRealm = realmService.getTenantUserRealm(tenantId);
+                ClaimManager claimManager;
+                if (userRealm != null) {
+                    //get claim manager for manipulating attributes
+                    claimManager = (ClaimManager) userRealm.getClaimManager();
+
+
+                    String authenticatedUser = PrivilegedCarbonContext.getThreadLocalCarbonContext().getUsername();
+                    if (authenticatedUser == null) {
+                        PrivilegedCarbonContext.getThreadLocalCarbonContext().setUsername(tenantLessUserName);
+                        if (log.isDebugEnabled()) {
+                            log.debug("User read from carbon context is null, hence setting " +
+                                    "authenticated user: " + tenantLessUserName);
+                        }
+                    }
+
+                    ldapUserManager = new LDAPUserManager((UserStoreManager) userRealm.getUserStoreManager(), username,
+                            claimManager);
+                    // ldapUserManager.createUser();
+                }
+
+            }
+
+
+        } catch (Exception ex) {
+            throw new IdentityLdapException("Error occur while getting userstore manager", ex);
+        }
+
+        return ldapUserManager;
+    }
+}

--- a/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/provider/IdentityLDAPManager.java
+++ b/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/provider/IdentityLDAPManager.java
@@ -31,8 +31,9 @@ public class IdentityLDAPManager {
 
     private static final Log log = LogFactory.getLog(IdentityLDAPManager.class);
 
-    public LDAPUserManager getUserManager(String username) throws Exception {
+    public LDAPUserManager getUserManager() throws Exception {
         LDAPUserManager ldapUserManager = null;
+        String username="carbon.super";
         String tenantDomain = MultitenantUtils.getTenantDomain(username);
         String tenantLessUserName = MultitenantUtils.getTenantAwareUsername(username);
 

--- a/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/provider/IdentityLDAPManager.java
+++ b/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/provider/IdentityLDAPManager.java
@@ -27,6 +27,9 @@ import org.wso2.carbon.user.core.claim.ClaimManager;
 import org.wso2.carbon.user.core.service.RealmService;
 import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 
+/**
+ * Class which use for, to get carbon user store manager.
+ */
 public class IdentityLDAPManager {
 
     private static final Log log = LogFactory.getLog(IdentityLDAPManager.class);

--- a/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/provider/IdentityLDAPManager.java
+++ b/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/provider/IdentityLDAPManager.java
@@ -36,7 +36,7 @@ public class IdentityLDAPManager {
 
     public LDAPUserManager getUserManager() throws IdentityLdapException {
         LDAPUserManager ldapUserManager = null;
-        String username="carbon.super";
+        String username = "carbon.super";
         String tenantDomain = MultitenantUtils.getTenantDomain(username);
         String tenantLessUserName = MultitenantUtils.getTenantAwareUsername(username);
 

--- a/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/provider/LDAPAttributeMapper.java
+++ b/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/provider/LDAPAttributeMapper.java
@@ -41,7 +41,6 @@ public class LDAPAttributeMapper {
             String attributeClaimUri = ldapClaimUri.append(attributkey).toString();
             claimsMap.put(attributeClaimUri, attributeValue);
         }
-
         return claimsMap;
     }
 
@@ -55,8 +54,6 @@ public class LDAPAttributeMapper {
                 userAttributes.put(attrId, attribute.getValue().toString());
             }
         }
-
         return userAttributes;
-
     }
 }

--- a/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/provider/LDAPAttributeMapper.java
+++ b/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/provider/LDAPAttributeMapper.java
@@ -23,6 +23,10 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 
+/**
+ * This class is use for the attached the ldap external claim to ladp attribute.
+ * After it will returns the attribute set as claim map.
+ */
 public class LDAPAttributeMapper {
 
     private static final Log log = LogFactory.getLog(LDAPAttributeMapper.class);

--- a/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/provider/LDAPAttributeMapper.java
+++ b/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/provider/LDAPAttributeMapper.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.carbon.identity.inbound.ldap.provider;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+public class LDAPAttributeMapper {
+
+    private static final Log log = LogFactory.getLog(LDAPAttributeMapper.class);
+
+    public Map<String, String> getAddUserClaimsMap(HashMap<String, String> ldapAttrSet) {
+        Map<String, String> claimsMap = new HashMap<>();
+
+        HashMap userAttributes = (HashMap) removeObjectClassAttribute(ldapAttrSet);
+        Iterator ldapAttribute = userAttributes.entrySet().iterator();
+
+        while (ldapAttribute.hasNext()) {
+            Map.Entry attribute = (Map.Entry) ldapAttribute.next();
+            String attributkey = attribute.getKey().toString();
+            String attributeValue = attribute.getValue().toString();
+            StringBuilder ldapClaimUri = new StringBuilder(LDAPConstants.LDAP_CLAIM_URI);
+            String attributeClaimUri = ldapClaimUri.append(attributkey).toString();
+            claimsMap.put(attributeClaimUri, attributeValue);
+        }
+
+        return claimsMap;
+    }
+
+    private Map<String, String> removeObjectClassAttribute(HashMap<String, String> attributesMap) {
+        HashMap userAttributes = new HashMap();
+        Iterator itr = attributesMap.entrySet().iterator();
+        while (itr.hasNext()) {
+            Map.Entry attribute = (Map.Entry) itr.next();
+            String attrId = attribute.getKey().toString();
+            if (!attrId.equals("objectclass")) {
+                userAttributes.put(attrId, attribute.getValue().toString());
+            }
+        }
+
+        return userAttributes;
+
+    }
+}

--- a/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/provider/LDAPConstants.java
+++ b/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/provider/LDAPConstants.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.carbon.identity.inbound.ldap.provider;
+
+public class LDAPConstants {
+
+
+    public static final String LDAP_CLAIM_URI = "http://wso2.org/ldap/claim/";
+
+    public static class LDAPSchemaConstants {
+
+        public static final String LDAP_SCHEMA_URI = "http://wso2.org/ldap/claim";
+        public static final String GIVEN_NAME_URI = "http://wso2.org/ldap/claim/givenName";
+        public static final String GIVEN_NAME = "givenName";
+        public static final String NICK_NAME_URI = "http://wso2.org/ldap/claim/nickName";
+        public static final String NICK_NAME = "nickName";
+        public static final String LAST_NAME_URI = "http://wso2.org/ldap/claim/sn";
+        public static final String LAST_NAME = "sn";
+        public static final String EMAIL_ADDRESS_URI = "http://wso2.org/ldap/claim/mail";
+        public static final String EMAIL_ADDRESS = "mail";
+        public static final String DATE_OF_BIRTH_URI = "http://wso2.org/ldap/claim/dateOfBirth";
+        public static final String DATE_OF_BIRTH = "DOB";
+        public static final String GENDER_URI = "http://wso2.org/ldap/claim/gender";
+        public static final String GENDER = "gender";
+        public static final String COUNTRY_URI = "http://wso2.org/ldap/claim/country";
+        public static final String COUNTRY = "country";
+        public static final String STREET_ADDRESS_URI = "http://wso2.org/ldap/claim/streetAddress";
+        public static final String STREET_ADDRESS = "streetAddress";
+        public static final String HOME_PHONE_URI = "http://wso2.org/ldap/claim/homePhone";
+        public static final String HOME_PHONE = "homePhone";
+        public static final String OTHER_PHONE_URI = "http://wso2.org/ldap/claim/otherPhone";
+        public static final String OTHER_PHONE = "otherPhone";
+        public static final String MOBILE_URI = "http://wso2.org/ldap/claim/mobile";
+        public static final String MOBILE = "mobile";
+        public static final String LOCALITY_NAME_URI = "http://wso2.org/ldap/claim/localityName";
+        public static final String LOCALITY_NAME = "localityName";
+        public static final String STATE_OR_PROVINCE_NAME_URI = "http://wso2.org/ldap/claim/stateOrProvinceName";
+        public static final String STATE_OR_PROVINCE_NAME = "stateOrProvinceName";
+        public static final String POSTAL_CODE_URI = "http://wso2.org/ldap/claim/postalCode";
+        public static final String POSTAL_CODE = "postalCode";
+        public static final String PPID_URI = "http://wso2.org/ldap/claim/PPID";
+        public static final String PPID = "privatePersonalIdentifier";
+        public static final String CN_URI = "http://wso2.org/ldap/claim/cn";
+        public static final String CN = "cn";
+        public static final String ORGANIZATION_URI = "http://wso2.org/ldap/claim/organizationName";
+        public static final String ORGANIZATION = "organizationName";
+        public static final String TELEPHONE_URI = "http://wso2.org/ldap/claim/telephoneNumber";
+        public static final String TELEPHONE = "telephoneNumber";
+        public static final String USERNAME_URI = "http://wso2.org/ldap/claim/uid";
+        public static final String USERNAME = "uid";
+        public static final String PASSWORD_URI = "http://wso2.org/ldap/claim/userpassword";
+        public static final String PASSWORD = "userPassword";
+        public static final String ROLE_URI = "http://wso2.org/ldap/claim/role";
+        public static final String ROLE = "role";
+        public static final String CREATED_TIME_URI = "http://wso2.org/ldap/claim/createdDate";
+        public static final String CREATED_TIME = "createdDate";
+        public static final String IM_URI = "http://wso2.org/ldap/claim/im";
+        public static final String IM = "im";
+        public static final String MODIFIED_TIME_URI = "http://wso2.org/ldap/claim/lastModifiedDate";
+        public static final String MODIFIED_TIME = "lastModifiedDate";
+        public static final String SCIM_ID_URI = "http://wso2.org/ldap/claim/scimId";
+        public static final String SCIM_ID = "scimId";
+
+
+    }
+
+}

--- a/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/provider/LDAPConstants.java
+++ b/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/provider/LDAPConstants.java
@@ -16,6 +16,9 @@
 
 package org.wso2.carbon.identity.inbound.ldap.provider;
 
+/**
+ * This class has been use for the introduce new ldap claim dialect for IS.
+ */
 public class LDAPConstants {
 
 

--- a/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/provider/LDAPConstants.java
+++ b/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/provider/LDAPConstants.java
@@ -74,8 +74,5 @@ public class LDAPConstants {
         public static final String MODIFIED_TIME = "lastModifiedDate";
         public static final String SCIM_ID_URI = "http://wso2.org/ldap/claim/scimId";
         public static final String SCIM_ID = "scimId";
-
-
     }
-
 }

--- a/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/provider/LDAPUser.java
+++ b/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/provider/LDAPUser.java
@@ -22,6 +22,9 @@ import org.apache.directory.shared.ldap.entry.EntryAttribute;
 import java.util.HashMap;
 import java.util.Iterator;
 
+/**
+ * This class has been use for the set ldapUser attributes.
+ */
 public class LDAPUser {
 
     private String username;

--- a/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/provider/LDAPUser.java
+++ b/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/provider/LDAPUser.java
@@ -58,5 +58,4 @@ public class LDAPUser {
             this.userAttributes.put(attrId, attrValue);
         }
     }
-
 }

--- a/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/provider/LDAPUser.java
+++ b/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/provider/LDAPUser.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.carbon.identity.inbound.ldap.provider;
+
+import org.apache.directory.shared.ldap.entry.Entry;
+import org.apache.directory.shared.ldap.entry.EntryAttribute;
+
+import java.util.HashMap;
+import java.util.Iterator;
+
+public class LDAPUser {
+
+    private String username;
+    private String password;
+    private HashMap userAttributes;
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getUserName() {
+        return this.username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String passowrd) {
+        this.password = passowrd;
+    }
+
+    public HashMap getUserAttributes() {
+        return userAttributes;
+    }
+
+    public void setUserAttributes(Entry entry) {
+        userAttributes = new HashMap();
+        Iterator itr = entry.iterator();
+        while (itr.hasNext()) {
+            EntryAttribute entryAttribute = (EntryAttribute) itr.next();
+            String attrId = entryAttribute.getId().toString();
+            String attrValue = entry.get(attrId).get().getString();
+            this.userAttributes.put(attrId, attrValue);
+        }
+    }
+
+}

--- a/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/provider/LDAPUserManager.java
+++ b/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/provider/LDAPUserManager.java
@@ -20,6 +20,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.inbound.ldap.utils.IdentityLdapException;
+import org.wso2.carbon.user.core.UserStoreException;
 import org.wso2.carbon.user.core.UserStoreManager;
 import org.wso2.carbon.user.core.claim.ClaimManager;
 import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
@@ -49,7 +50,7 @@ public class LDAPUserManager {
         carbonContext.setUsername(MultitenantUtils.getTenantAwareUsername("carbon.super"));
     }
 
-    public void createUser(LDAPUser ldapUser) throws Exception { //LDAPUser ldapuser, boolean isBulkAdd
+    public void createUser(LDAPUser ldapUser) throws IdentityLdapException { //LDAPUser ldapuser, boolean isBulkAdd
         try {
 
             String username = ldapUser.getUserName();
@@ -71,18 +72,18 @@ public class LDAPUserManager {
             carbonUM.addUser(ldapUser.getUserName(), ldapUser.getPassword(), null, claimsMap, null);
             log.info("User: " + ldapUser.getUserName() + " is created through LDAP protocol.");
 
-        } catch (Exception e) {
+        } catch (UserStoreException e) {
             throw new IdentityLdapException("Error occurred while adding user", e);
         }
     }
 
-    public void deleteUser(String userId) throws Exception {
+    public void deleteUser(String userId) throws IdentityLdapException {
         try {
             // Here assume (since id is unique per user) only one user exists for a given id
             carbonUM.deleteUser(userId);
             log.info("User: " + userId + " is deleted through LDAP.");
 
-        } catch (Exception ex) {
+        } catch (UserStoreException ex) {
             throw new IdentityLdapException("Error occurred while deleting user", ex);
         }
     }

--- a/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/provider/LDAPUserManager.java
+++ b/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/provider/LDAPUserManager.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.carbon.identity.inbound.ldap.provider;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.carbon.identity.inbound.ldap.utils.IdentityLdapException;
+import org.wso2.carbon.user.core.UserStoreManager;
+import org.wso2.carbon.user.core.claim.ClaimManager;
+import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
+
+import java.util.HashMap;
+
+public class LDAPUserManager {
+
+    private static final Log log = LogFactory.getLog(LDAPUserManager.class);
+    private UserStoreManager carbonUM = null;
+    private ClaimManager carbonClaimManager = null;
+    private String consumerName;
+
+
+    public LDAPUserManager(UserStoreManager carbonUserStoreManager, String username, ClaimManager claimManager) {
+        carbonUM = carbonUserStoreManager;
+        carbonClaimManager = claimManager;
+        consumerName = username;
+        startTenantFlow();
+    }
+
+    private void startTenantFlow() {
+        PrivilegedCarbonContext.startTenantFlow();
+        PrivilegedCarbonContext carbonContext = PrivilegedCarbonContext.getThreadLocalCarbonContext();
+        carbonContext.setTenantDomain(MultitenantUtils.getTenantDomain("carbon.super"));
+        carbonContext.getTenantId(true);
+        carbonContext.setUsername(MultitenantUtils.getTenantAwareUsername("carbon.super"));
+    }
+
+    public void createUser(LDAPUser ldapUser) throws Exception { //LDAPUser ldapuser, boolean isBulkAdd
+        try {
+
+            String username = ldapUser.getUserName();
+
+
+            LDAPAttributeMapper ldapAttributeMapper = new LDAPAttributeMapper();
+            HashMap<String, String> claimsMap = (HashMap<String, String>) ldapAttributeMapper.getAddUserClaimsMap
+                    (ldapUser.getUserAttributes());
+
+
+            if (carbonUM.isExistingUser(username)) {
+                String error = "User with the name : " + username + " already exist in the system";
+                log.info(error);
+                throw new IdentityLdapException(error);
+            }
+
+
+            if (claimsMap.containsKey(LDAPConstants.LDAPSchemaConstants.PASSWORD_URI)) {
+                claimsMap.remove(LDAPConstants.LDAPSchemaConstants.PASSWORD_URI);
+            }
+
+            carbonUM.addUser(ldapUser.getUserName(), ldapUser.getPassword(), null, claimsMap, null);
+            log.info("User: " + ldapUser.getUserName() + " is created through LDAP protocol.");
+
+        } catch (Exception e) {
+            throw new IdentityLdapException("Error occurred while adding user", e);
+        }
+
+    }
+
+    public void deleteUser(String userId) throws Exception {
+        try {
+
+            // Here assume (since id is unique per user) only one user exists for a given id
+
+            carbonUM.deleteUser(userId);
+            log.info("User: " + userId + " is deleted through LDAP.");
+
+        } catch (Exception ex) {
+            throw new IdentityLdapException("Error occurred while deleting user", ex);
+        }
+    }
+
+}

--- a/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/provider/LDAPUserManager.java
+++ b/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/provider/LDAPUserManager.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.carbon.identity.inbound.ldap.provider;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.carbon.identity.inbound.ldap.utils.IdentityLdapException;
+import org.wso2.carbon.user.core.UserStoreManager;
+import org.wso2.carbon.user.core.claim.ClaimManager;
+import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
+
+import java.util.HashMap;
+
+public class LDAPUserManager {
+
+    private static final Log log = LogFactory.getLog(LDAPUserManager.class);
+    private UserStoreManager carbonUM = null;
+    private ClaimManager carbonClaimManager = null;
+    private String consumerName;
+
+
+    public LDAPUserManager(UserStoreManager carbonUserStoreManager, String username, ClaimManager claimManager) {
+        carbonUM = carbonUserStoreManager;
+        carbonClaimManager = claimManager;
+        consumerName = username;
+        startTenantFlow();
+    }
+
+    private void startTenantFlow() {
+        PrivilegedCarbonContext.startTenantFlow();
+        PrivilegedCarbonContext carbonContext = PrivilegedCarbonContext.getThreadLocalCarbonContext();
+        carbonContext.setTenantDomain(MultitenantUtils.getTenantDomain("carbon.super"));
+        carbonContext.getTenantId(true);
+        carbonContext.setUsername(MultitenantUtils.getTenantAwareUsername("carbon.super"));
+    }
+
+    public void createUser(LDAPUser ldapUser) throws Exception { //LDAPUser ldapuser, boolean isBulkAdd
+        try {
+
+            String username = ldapUser.getUserName();
+
+
+            LDAPAttributeMapper ldapAttributeMapper = new LDAPAttributeMapper();
+            HashMap<String, String> claimsMap = (HashMap<String, String>) ldapAttributeMapper.getAddUserClaimsMap(ldapUser.getUserAttributes());
+
+
+            if (carbonUM.isExistingUser(username)) {
+                String error = "User with the name : " + username + " already exist in the system";
+                log.info(error);
+                throw new IdentityLdapException(error);
+            }
+
+
+            if (claimsMap.containsKey(LDAPConstants.LDAPSchemaConstants.PASSWORD_URI)) {
+                claimsMap.remove(LDAPConstants.LDAPSchemaConstants.PASSWORD_URI);
+            }
+
+            carbonUM.addUser(ldapUser.getUserName(), ldapUser.getPassword(), null, claimsMap, null);
+            log.info("User: " + ldapUser.getUserName() + " is created through LDAP protocol.");
+
+        } catch (Exception e) {
+            throw new IdentityLdapException("Error occurred while adding user", e);
+        }
+
+    }
+
+    public void deleteUser(String userId) throws Exception {
+        try {
+
+            // Here assume (since id is unique per user) only one user exists for a given id
+
+            carbonUM.deleteUser(userId);
+            log.info("User: " + userId + " is deleted through LDAP.");
+
+        } catch (Exception ex) {
+            throw new IdentityLdapException("Error occurred while deleting user", ex);
+        }
+    }
+
+}

--- a/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/provider/LDAPUserManager.java
+++ b/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/provider/LDAPUserManager.java
@@ -54,18 +54,15 @@ public class LDAPUserManager {
 
             String username = ldapUser.getUserName();
 
-
             LDAPAttributeMapper ldapAttributeMapper = new LDAPAttributeMapper();
             HashMap<String, String> claimsMap = (HashMap<String, String>) ldapAttributeMapper.getAddUserClaimsMap
                     (ldapUser.getUserAttributes());
-
 
             if (carbonUM.isExistingUser(username)) {
                 String error = "User with the name : " + username + " already exist in the system";
                 log.info(error);
                 throw new IdentityLdapException(error);
             }
-
 
             if (claimsMap.containsKey(LDAPConstants.LDAPSchemaConstants.PASSWORD_URI)) {
                 claimsMap.remove(LDAPConstants.LDAPSchemaConstants.PASSWORD_URI);
@@ -77,14 +74,11 @@ public class LDAPUserManager {
         } catch (Exception e) {
             throw new IdentityLdapException("Error occurred while adding user", e);
         }
-
     }
 
     public void deleteUser(String userId) throws Exception {
         try {
-
             // Here assume (since id is unique per user) only one user exists for a given id
-
             carbonUM.deleteUser(userId);
             log.info("User: " + userId + " is deleted through LDAP.");
 

--- a/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/provider/LDAPUserManager.java
+++ b/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/provider/LDAPUserManager.java
@@ -27,6 +27,9 @@ import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 
 import java.util.HashMap;
 
+/**
+ * This class has been use for the mange ldap users with wso2 user store manager
+ */
 public class LDAPUserManager {
 
     private static final Log log = LogFactory.getLog(LDAPUserManager.class);
@@ -39,7 +42,6 @@ public class LDAPUserManager {
         carbonUM = carbonUserStoreManager;
         carbonClaimManager = claimManager;
         consumerName = username;
-        startTenantFlow();
     }
 
     private void startTenantFlow() {
@@ -59,6 +61,8 @@ public class LDAPUserManager {
             HashMap<String, String> claimsMap = (HashMap<String, String>) ldapAttributeMapper.getAddUserClaimsMap
                     (ldapUser.getUserAttributes());
 
+            startTenantFlow();
+
             if (carbonUM.isExistingUser(username)) {
                 String error = "User with the name : " + username + " already exist in the system";
                 log.info(error);
@@ -75,16 +79,23 @@ public class LDAPUserManager {
         } catch (UserStoreException e) {
             throw new IdentityLdapException("Error occurred while adding user", e);
         }
+        finally{
+            PrivilegedCarbonContext.endTenantFlow();
+        }
     }
 
     public void deleteUser(String userId) throws IdentityLdapException {
         try {
+            startTenantFlow();
             // Here assume (since id is unique per user) only one user exists for a given id
             carbonUM.deleteUser(userId);
             log.info("User: " + userId + " is deleted through LDAP.");
 
         } catch (UserStoreException ex) {
             throw new IdentityLdapException("Error occurred while deleting user", ex);
+        }
+        finally{
+            PrivilegedCarbonContext.endTenantFlow();
         }
     }
 

--- a/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/provider/LDAPUserManager.java
+++ b/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/provider/LDAPUserManager.java
@@ -34,9 +34,6 @@ public class LDAPUserManager {
 
     private static final Log log = LogFactory.getLog(LDAPUserManager.class);
     private UserStoreManager carbonUM = null;
-    private ClaimManager carbonClaimManager = null;
-    private String consumerName;
-
 
     public LDAPUserManager(UserStoreManager carbonUserStoreManager, String username, ClaimManager claimManager) {
         carbonUM = carbonUserStoreManager;
@@ -78,8 +75,7 @@ public class LDAPUserManager {
 
         } catch (UserStoreException e) {
             throw new IdentityLdapException("Error occurred while adding user", e);
-        }
-        finally{
+        } finally {
             PrivilegedCarbonContext.endTenantFlow();
         }
     }
@@ -93,8 +89,7 @@ public class LDAPUserManager {
 
         } catch (UserStoreException ex) {
             throw new IdentityLdapException("Error occurred while deleting user", ex);
-        }
-        finally{
+        } finally {
             PrivilegedCarbonContext.endTenantFlow();
         }
     }

--- a/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/utils/ConfigurartionBuilder.java
+++ b/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/utils/ConfigurartionBuilder.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wso2.carbon.identity.inbound.ldap.utils;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+import org.wso2.carbon.identity.inbound.ldap.impl.EndPointConfiguration;
+import org.xml.sax.SAXException;
+
+import java.io.File;
+import java.io.IOException;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+
+public class ConfigurartionBuilder {
+
+    private String connectionPassword;
+    private EndPointConfiguration endPointConfiguration;
+    private NodeList ldapEndpointConfiguration;
+
+    public EndPointConfiguration getEndPointConfiguration() {
+        return endPointConfiguration;
+    }
+
+    public void buildConfiguration(File inputFile) throws IdentityLdapException {
+        //NodeList ldapEndpointConfiguration = null;
+        try {
+            // File inputFile = new File(file);
+            System.setProperty("javax.xml.parsers.DocumentBuilderFactory",
+                    "org.apache.xerces.jaxp.DocumentBuilderFactoryImpl");
+            DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
+            DocumentBuilder dBuilder = null;
+            dBuilder = dbFactory.newDocumentBuilder();
+            Document doc = dBuilder.parse(inputFile);
+            doc.getDocumentElement().normalize();
+
+            ldapEndpointConfiguration = doc.getElementsByTagName("LDAPEndPointConfig");
+
+        } catch (ParserConfigurationException e) {
+            throw new IdentityLdapException("", e);
+        } catch (SAXException e) {
+            throw new IdentityLdapException("", e);
+        } catch (IOException e) {
+            throw new IdentityLdapException("", e);
+        }
+    }
+
+
+    public void buildLDAPEndpointConfigurartion() {
+        Element ele = null;
+        ele = (Element) ldapEndpointConfiguration.item(0);
+        endPointConfiguration = new EndPointConfiguration();
+
+        endPointConfiguration.setAllowAnonymousAccess(getBooleanValue(getValue(ele, "allowAnonymousAccess")));
+        endPointConfiguration.setAccessControlOn(getBooleanValue(getValue(ele, "accessControlEnabled")));
+        endPointConfiguration.setDeNormalizedAttributesEnabled(getBooleanValue(getValue(ele,
+                "denormalizeOpAttrsEnabled")));
+        endPointConfiguration.setEnable(getBooleanValue(getValue(ele, "enable")));
+        endPointConfiguration.setSaslHostName(getValue(ele, "saslHostName"));
+        endPointConfiguration.setSaslPrincipalName(getValue(ele, "saslPrincipalName"));
+        endPointConfiguration.setWorkingDirectory(getValue(ele, "workingDirectory"));
+        endPointConfiguration.setInstanceId(getValue(ele, "instanceId"));
+        endPointConfiguration.setEndpointPort(getIntegerValue(getValue(ele, "port")));
+        endPointConfiguration.setMaxPDUSize(getIntegerValue(getValue(ele, "maxPDUSize")));
+        connectionPassword = ele.getElementsByTagName("connectionPassword").item(0).getTextContent();
+    }
+
+
+    private int getIntegerValue(String value) {
+        if (value != null) {
+            return Integer.parseInt(value);
+        }
+        return -1;
+    }
+
+    private boolean getBooleanValue(String value) {
+        if (value != null) {
+            return Boolean.parseBoolean(value);
+        }
+        return false;
+    }
+
+    private String getValue(Element ele, String tagName) {
+        return ele.getElementsByTagName(tagName).item(0).getTextContent();
+    }
+
+    public String getConnectionPassword() {
+        return connectionPassword;
+    }
+
+    public boolean isLdapEndpointEnabled() {
+        return endPointConfiguration.isEnable();
+    }
+
+}

--- a/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/utils/ConfigurartionBuilder.java
+++ b/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/utils/ConfigurartionBuilder.java
@@ -60,7 +60,6 @@ public class ConfigurartionBuilder {
         }
     }
 
-
     public void buildLDAPEndpointConfigurartion() {
         Element ele = null;
         ele = (Element) ldapEndpointConfiguration.item(0);
@@ -79,7 +78,6 @@ public class ConfigurartionBuilder {
         endPointConfiguration.setMaxPDUSize(getIntegerValue(getValue(ele, "maxPDUSize")));
         connectionPassword = ele.getElementsByTagName("connectionPassword").item(0).getTextContent();
     }
-
 
     private int getIntegerValue(String value) {
         if (value != null) {

--- a/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/utils/ConfigurartionBuilder.java
+++ b/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/utils/ConfigurartionBuilder.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wso2.carbon.identity.inbound.ldap.utils;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+import org.wso2.carbon.identity.inbound.ldap.impl.EndPointConfiguration;
+import org.xml.sax.SAXException;
+
+import java.io.File;
+import java.io.IOException;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+
+public class ConfigurartionBuilder {
+
+    private String connectionPassword;
+    private EndPointConfiguration endPointConfiguration;
+    private NodeList ldapEndpointConfiguration;
+
+    public EndPointConfiguration getEndPointConfiguration() {
+        return endPointConfiguration;
+    }
+
+    public void buildConfiguration(File inputFile) throws IdentityLdapException {
+        //NodeList ldapEndpointConfiguration = null;
+        try {
+            // File inputFile = new File(file);
+            System.setProperty("javax.xml.parsers.DocumentBuilderFactory", "org.apache.xerces.jaxp.DocumentBuilderFactoryImpl");
+            DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
+            DocumentBuilder dBuilder = null;
+            dBuilder = dbFactory.newDocumentBuilder();
+            Document doc = dBuilder.parse(inputFile);
+            doc.getDocumentElement().normalize();
+
+            ldapEndpointConfiguration = doc.getElementsByTagName("LDAPEndPointConfig");
+
+        } catch (ParserConfigurationException e) {
+            throw new IdentityLdapException("", e);
+        } catch (SAXException e) {
+            throw new IdentityLdapException("", e);
+        } catch (IOException e) {
+            throw new IdentityLdapException("", e);
+        }
+    }
+
+
+    public void buildLDAPEndpointConfigurartion() {
+
+        System.out.println(ldapEndpointConfiguration.getLength());
+        Element ele = null;
+        ele = (Element) ldapEndpointConfiguration.item(0);
+        endPointConfiguration = new EndPointConfiguration();
+
+        endPointConfiguration.setAllowAnonymousAccess(getBooleanValue(getValue(ele, "allowAnonymousAccess")));
+        endPointConfiguration.setAccessControlOn(getBooleanValue(getValue(ele, "accessControlEnabled")));
+        endPointConfiguration.setDeNormalizedAttributesEnabled(getBooleanValue(getValue(ele, "denormalizeOpAttrsEnabled")));
+        endPointConfiguration.setEnable(getBooleanValue(getValue(ele, "enable")));
+        endPointConfiguration.setSaslHostName(getValue(ele, "saslHostName"));
+        endPointConfiguration.setSaslPrincipalName(getValue(ele, "saslPrincipalName"));
+        endPointConfiguration.setWorkingDirectory(getValue(ele, "workingDirectory"));
+        endPointConfiguration.setInstanceId(getValue(ele, "instanceId"));
+        endPointConfiguration.setEndpointPort(getIntegerValue(getValue(ele, "port")));
+        endPointConfiguration.setMaxPDUSize(getIntegerValue(getValue(ele, "maxPDUSize")));
+        connectionPassword = ele.getElementsByTagName("connectionPassword").item(0).getTextContent();
+    }
+
+
+    private int getIntegerValue(String value) {
+        if (value != null) {
+            return Integer.parseInt(value);
+        }
+        return -1;
+    }
+
+    private boolean getBooleanValue(String value) {
+        if (value != null) {
+            return Boolean.parseBoolean(value);
+        }
+        return false;
+    }
+
+    private String getValue(Element ele, String tagName) {
+        System.out.println(ele.getElementsByTagName(tagName).item(0).getTextContent());
+        return ele.getElementsByTagName(tagName).item(0).getTextContent();
+    }
+
+    public String getConnectionPassword() {
+        return connectionPassword;
+    }
+
+    public boolean isLdapEndpointEnabled() {
+        return endPointConfiguration.isEnable();
+    }
+
+}

--- a/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/utils/ConfigurationBuilder.java
+++ b/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/utils/ConfigurationBuilder.java
@@ -27,6 +27,9 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
+/**
+ * This class has been use for the read ldap endpoint configuration file.
+ */
 public class ConfigurationBuilder {
 
     private String connectionPassword;

--- a/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/utils/ConfigurationBuilder.java
+++ b/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/utils/ConfigurationBuilder.java
@@ -27,7 +27,7 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
-public class ConfigurartionBuilder {
+public class ConfigurationBuilder {
 
     private String connectionPassword;
     private EndPointConfiguration endPointConfiguration;

--- a/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/utils/IdentityIOStreamUtils.java
+++ b/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/utils/IdentityIOStreamUtils.java
@@ -1,19 +1,17 @@
 /*
- * Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
- * Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.wso2.carbon.identity.inbound.ldap.utils;

--- a/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/utils/IdentityIOStreamUtils.java
+++ b/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/utils/IdentityIOStreamUtils.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.inbound.ldap.utils;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+public class IdentityIOStreamUtils {
+
+    private static final Log log = LogFactory.getLog(IdentityIOStreamUtils.class);
+
+    public static void closeAllStreams(InputStream input, OutputStream output) throws IdentityLdapException {
+        closeInputStream(input);
+        closeOutputStream(output);
+    }
+
+    public static void closeInputStream(InputStream input) throws IdentityLdapException {
+        try {
+            if (input != null) {
+                input.close();
+            }
+        } catch (IOException ioe) {
+            String msg = "Error occurred while closing Input stream";
+            log.error(msg);
+            throw new IdentityLdapException(msg, ioe);
+        }
+    }
+
+    public static void closeOutputStream(OutputStream output) throws IdentityLdapException {
+        try {
+            if (output != null) {
+                output.close();
+            }
+        } catch (IOException ioe) {
+            String msg = "Error occurred while closing Output stream";
+            log.error(msg);
+            throw new IdentityLdapException(msg, ioe);
+        }
+    }
+
+    public static void flushOutputStream(OutputStream output) throws IdentityLdapException {
+        try {
+            if (output != null) {
+                output.flush();
+            }
+        } catch (IOException ioe) {
+            String msg = "Error occurred while flushing Output stream";
+            log.error(msg);
+            throw new IdentityLdapException(msg, ioe);
+        }
+    }
+}

--- a/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/utils/IdentityLdapException.java
+++ b/components/org.wso2.carbon.identity.inbound.ldap/src/main/java/org/wso2/carbon/identity/inbound/ldap/utils/IdentityLdapException.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.carbon.identity.inbound.ldap.utils;
+
+import org.wso2.carbon.identity.base.IdentityException;
+
+public class IdentityLdapException extends IdentityException {
+
+    public IdentityLdapException(String message) {
+        super(message);
+    }
+
+    public IdentityLdapException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/components/org.wso2.carbon.identity.inbound.ldap/src/test/java/org/wso2/carbon/identity/inbound/ldap/provider/IdentityLDAPManagerTest.java
+++ b/components/org.wso2.carbon.identity.inbound.ldap/src/test/java/org/wso2/carbon/identity/inbound/ldap/provider/IdentityLDAPManagerTest.java
@@ -77,7 +77,7 @@ public class IdentityLDAPManagerTest extends PowerMockTestCase {
         when(realmService.getTenantUserRealm(anyInt())).thenReturn(userRealm);
         when(userRealm.getClaimManager()).thenReturn(claimManager);
         String authenticatedUser = PrivilegedCarbonContext.getThreadLocalCarbonContext().getUsername();
-        identityLDAPManager.getUserManager("admin");
+        identityLDAPManager.getUserManager();
         assertNotNull(authenticatedUser);
         assertEquals(authenticatedUser, "admin", "usernames are not matched");
 

--- a/components/org.wso2.carbon.identity.inbound.ldap/src/test/java/org/wso2/carbon/identity/inbound/ldap/provider/IdentityLDAPManagerTest.java
+++ b/components/org.wso2.carbon.identity.inbound.ldap/src/test/java/org/wso2/carbon/identity/inbound/ldap/provider/IdentityLDAPManagerTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.carbon.identity.inbound.ldap.provider;
+
+import org.apache.axis2.util.XMLUtils;
+import org.mockito.Mock;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.testng.PowerMockTestCase;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+import org.wso2.carbon.base.CarbonBaseConstants;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.carbon.identity.inbound.ldap.internal.LDAPEPComponentHolder;
+import org.wso2.carbon.user.core.UserRealm;
+import org.wso2.carbon.user.core.claim.ClaimManager;
+import org.wso2.carbon.user.core.service.RealmService;
+import org.wso2.carbon.user.core.tenant.TenantManager;
+import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
+
+import java.nio.file.Paths;
+
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.when;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+@PrepareForTest({MultitenantUtils.class, LDAPEPComponentHolder.class, XMLUtils.class})
+@PowerMockIgnore({"javax.net.*", "javax.security.*", "javax.crypto.*", "javax.xml.*", "XMLUtils.java"})
+public class IdentityLDAPManagerTest extends PowerMockTestCase {
+
+    @Mock
+    RealmService realmService;
+    @Mock
+    UserRealm userRealm;
+    @Mock
+    ClaimManager claimManager;
+    @Mock
+    TenantManager tenantManager;
+    private IdentityLDAPManager identityLDAPManager;
+
+    @BeforeTest
+    public void setUp() throws Exception {
+        identityLDAPManager = new IdentityLDAPManager();
+        String carbonHome = Paths.get(System.getProperty("user.dir"), "target").toString();
+        System.setProperty(CarbonBaseConstants.CARBON_HOME, carbonHome);
+        PrivilegedCarbonContext.startTenantFlow();
+        PrivilegedCarbonContext.getThreadLocalCarbonContext().setUsername("admin");
+        identityLDAPManager = new IdentityLDAPManager();
+    }
+
+    @Test
+    public void testGetUserManager() throws Exception {
+        mockStatic(MultitenantUtils.class);
+        when(MultitenantUtils.getTenantDomain(anyString())).thenReturn("tenantDomain");
+        when(MultitenantUtils.getTenantAwareUsername(anyString())).thenReturn("tenantLessname");
+        mockStatic(LDAPEPComponentHolder.class);
+        when(LDAPEPComponentHolder.getRealmService()).thenReturn(realmService);
+        when(realmService.getTenantManager()).thenReturn(tenantManager);
+        when(tenantManager.getTenantId(anyString())).thenReturn(1);
+        when(realmService.getTenantUserRealm(anyInt())).thenReturn(userRealm);
+        when(userRealm.getClaimManager()).thenReturn(claimManager);
+        String authenticatedUser = PrivilegedCarbonContext.getThreadLocalCarbonContext().getUsername();
+        identityLDAPManager.getUserManager("admin");
+        assertNotNull(authenticatedUser);
+        assertEquals(authenticatedUser, "admin", "usernames are not matched");
+
+    }
+
+}

--- a/components/org.wso2.carbon.identity.inbound.ldap/src/test/java/org/wso2/carbon/identity/inbound/ldap/provider/IdentityLDAPManagerTest.java
+++ b/components/org.wso2.carbon.identity.inbound.ldap/src/test/java/org/wso2/carbon/identity/inbound/ldap/provider/IdentityLDAPManagerTest.java
@@ -21,6 +21,7 @@ import org.mockito.Mock;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.testng.PowerMockTestCase;
+import org.testng.annotations.AfterTest;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 import org.wso2.carbon.base.CarbonBaseConstants;
@@ -63,6 +64,11 @@ public class IdentityLDAPManagerTest extends PowerMockTestCase {
         PrivilegedCarbonContext.startTenantFlow();
         PrivilegedCarbonContext.getThreadLocalCarbonContext().setUsername("admin");
         identityLDAPManager = new IdentityLDAPManager();
+    }
+
+    @AfterTest
+    public void afterTest() throws Exception {
+        PrivilegedCarbonContext.endTenantFlow();
     }
 
     @Test

--- a/components/org.wso2.carbon.identity.inbound.ldap/src/test/java/org/wso2/carbon/identity/inbound/ldap/provider/LDAPAttributeMapperTest.java
+++ b/components/org.wso2.carbon.identity.inbound.ldap/src/test/java/org/wso2/carbon/identity/inbound/ldap/provider/LDAPAttributeMapperTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.carbon.identity.inbound.ldap.provider;
+
+import org.junit.Test;
+
+import java.util.HashMap;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+
+public class LDAPAttributeMapperTest {
+
+    @Test
+    public void getClaimsMap() throws Exception {
+        LDAPAttributeMapper ldapAttributeMapper = new LDAPAttributeMapper();
+        HashMap ldapAttrSet = new HashMap();
+        ldapAttrSet.put("cn", "testcn");
+        ldapAttrSet.put("sn", "testsn");
+        ldapAttrSet.put("mail", "test@gmail.com");
+        ldapAttrSet.put("country", "SriLanka");
+        ldapAttrSet.put("organizationName", "WSO2");
+        ldapAttrSet.put("givenName", "abc");
+        ldapAttrSet.put("createdDate", "2017-10-02");
+        ldapAttrSet.put("lastModifiedDate", "2017-10-02T17:16:04");
+        ldapAttrSet.put("objectclass", "top");
+        ldapAttrSet.put("mobile", "0717463047");
+        ldapAttrSet.put("scimId", "e8c029b1-e397-412e-87db-2125bb3ada56");
+        HashMap claimMapExpected = (HashMap) ldapAttributeMapper.getAddUserClaimsMap(ldapAttrSet);
+
+
+        HashMap claimMap = new HashMap();
+        claimMap.put(LDAPConstants.LDAPSchemaConstants.CN_URI, "testcn");
+        claimMap.put(LDAPConstants.LDAPSchemaConstants.LAST_NAME_URI, "testsn");
+        claimMap.put(LDAPConstants.LDAPSchemaConstants.EMAIL_ADDRESS_URI, "test@gmail.com");
+        claimMap.put(LDAPConstants.LDAPSchemaConstants.COUNTRY_URI, "SriLanka");
+        claimMap.put(LDAPConstants.LDAPSchemaConstants.ORGANIZATION_URI, "WSO2");
+        claimMap.put(LDAPConstants.LDAPSchemaConstants.GIVEN_NAME_URI, "abc");
+        claimMap.put(LDAPConstants.LDAPSchemaConstants.CREATED_TIME_URI, "2017-10-02");
+        claimMap.put(LDAPConstants.LDAPSchemaConstants.MODIFIED_TIME_URI, "2017-10-02T17:16:04");
+        claimMap.put(LDAPConstants.LDAPSchemaConstants.MOBILE_URI, "0717463047");
+        claimMap.put(LDAPConstants.LDAPSchemaConstants.SCIM_ID_URI, "e8c029b1-e397-412e-87db-2125bb3ada56");
+
+        assertNotNull(claimMapExpected);
+        assertFalse(claimMapExpected.containsValue("top"));
+        assertEquals(claimMap, claimMapExpected);
+
+    }
+
+}

--- a/components/org.wso2.carbon.identity.inbound.ldap/src/test/java/org/wso2/carbon/identity/inbound/ldap/provider/LDAPAttributeMapperTest.java
+++ b/components/org.wso2.carbon.identity.inbound.ldap/src/test/java/org/wso2/carbon/identity/inbound/ldap/provider/LDAPAttributeMapperTest.java
@@ -16,9 +16,12 @@
 
 package org.wso2.carbon.identity.inbound.ldap.provider;
 
-import org.junit.Test;
+
+
+import org.testng.annotations.Test;
 
 import java.util.HashMap;
+import java.util.Map;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
@@ -41,7 +44,7 @@ public class LDAPAttributeMapperTest {
         ldapAttrSet.put("objectclass", "top");
         ldapAttrSet.put("mobile", "0717463047");
         ldapAttrSet.put("scimId", "e8c029b1-e397-412e-87db-2125bb3ada56");
-        HashMap claimMapExpected = (HashMap) ldapAttributeMapper.getAddUserClaimsMap(ldapAttrSet);
+        Map claimMapExpected = ldapAttributeMapper.getAddUserClaimsMap(ldapAttrSet);
 
         HashMap claimMap = new HashMap();
         claimMap.put(LDAPConstants.LDAPSchemaConstants.CN_URI, "testcn");

--- a/components/org.wso2.carbon.identity.inbound.ldap/src/test/java/org/wso2/carbon/identity/inbound/ldap/provider/LDAPAttributeMapperTest.java
+++ b/components/org.wso2.carbon.identity.inbound.ldap/src/test/java/org/wso2/carbon/identity/inbound/ldap/provider/LDAPAttributeMapperTest.java
@@ -43,7 +43,6 @@ public class LDAPAttributeMapperTest {
         ldapAttrSet.put("scimId", "e8c029b1-e397-412e-87db-2125bb3ada56");
         HashMap claimMapExpected = (HashMap) ldapAttributeMapper.getAddUserClaimsMap(ldapAttrSet);
 
-
         HashMap claimMap = new HashMap();
         claimMap.put(LDAPConstants.LDAPSchemaConstants.CN_URI, "testcn");
         claimMap.put(LDAPConstants.LDAPSchemaConstants.LAST_NAME_URI, "testsn");

--- a/components/org.wso2.carbon.identity.inbound.ldap/src/test/java/org/wso2/carbon/identity/inbound/ldap/utils/ConfigurartionBuilderTest.java
+++ b/components/org.wso2.carbon.identity.inbound.ldap/src/test/java/org/wso2/carbon/identity/inbound/ldap/utils/ConfigurartionBuilderTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.carbon.identity.inbound.ldap.utils;
+
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.inbound.ldap.impl.EndPointConfiguration;
+
+import java.io.File;
+
+import static org.testng.Assert.assertEquals;
+
+public class ConfigurartionBuilderTest {
+
+    private ConfigurartionBuilder configurartionBuilder;
+
+    @BeforeTest
+    public void setUp() throws Exception {
+        configurartionBuilder = new ConfigurartionBuilder();
+        configurartionBuilder.buildConfiguration(new File("src/test/resources/ldap-endpointconfig.xml"));
+        configurartionBuilder.buildLDAPEndpointConfigurartion();
+    }
+
+    @Test
+    public void testBuildLDAPEndpointConfigurartion() throws Exception {
+
+        EndPointConfiguration endPointConfiguration = configurartionBuilder.getEndPointConfiguration();
+        assertEquals(endPointConfiguration.getEndpointPort(), 10390);
+        assertEquals(endPointConfiguration.getInstanceId(), "default");
+        assertEquals(endPointConfiguration.getMaxPDUSize(), 2000000);
+        assertEquals(endPointConfiguration.isEnable(), true);
+        assertEquals(endPointConfiguration.getSaslHostName(), "localhost");
+        assertEquals(endPointConfiguration.getSaslPrincipalName(), "ldap/localhost@EXAMPLE.COM");
+        assertEquals(endPointConfiguration.isAllowAnonymousAccess(), false);
+        assertEquals(endPointConfiguration.isDeNormalizedAttributesEnabled(), false);
+        assertEquals(endPointConfiguration.isAccessControlOn(), true);
+
+    }
+
+    @Test
+    public void testGetConnectionPassword() throws Exception {
+        assertEquals(configurartionBuilder.getConnectionPassword(), "admin");
+    }
+
+    @Test
+    public void testIsEmbeddedLDAPEnabled() throws Exception {
+        assertEquals(configurartionBuilder.isLdapEndpointEnabled(), true);
+    }
+
+}

--- a/components/org.wso2.carbon.identity.inbound.ldap/src/test/java/org/wso2/carbon/identity/inbound/ldap/utils/ConfigurationBuilderTest.java
+++ b/components/org.wso2.carbon.identity.inbound.ldap/src/test/java/org/wso2/carbon/identity/inbound/ldap/utils/ConfigurationBuilderTest.java
@@ -24,21 +24,21 @@ import java.io.File;
 
 import static org.testng.Assert.assertEquals;
 
-public class ConfigurartionBuilderTest {
+public class ConfigurationBuilderTest {
 
-    private ConfigurartionBuilder configurartionBuilder;
+    private ConfigurationBuilder configurationBuilder;
 
     @BeforeTest
     public void setUp() throws Exception {
-        configurartionBuilder = new ConfigurartionBuilder();
-        configurartionBuilder.buildConfiguration(new File("src/test/resources/ldap-endpointconfig.xml"));
-        configurartionBuilder.buildLDAPEndpointConfigurartion();
+        configurationBuilder = new ConfigurationBuilder();
+        configurationBuilder.buildConfiguration(new File("src/test/resources/ldap-endpointconfig.xml"));
+        configurationBuilder.buildLDAPEndpointConfigurartion();
     }
 
     @Test
     public void testBuildLDAPEndpointConfigurartion() throws Exception {
 
-        EndPointConfiguration endPointConfiguration = configurartionBuilder.getEndPointConfiguration();
+        EndPointConfiguration endPointConfiguration = configurationBuilder.getEndPointConfiguration();
         assertEquals(endPointConfiguration.getEndpointPort(), 10390);
         assertEquals(endPointConfiguration.getInstanceId(), "default");
         assertEquals(endPointConfiguration.getMaxPDUSize(), 2000000);
@@ -53,12 +53,12 @@ public class ConfigurartionBuilderTest {
 
     @Test
     public void testGetConnectionPassword() throws Exception {
-        assertEquals(configurartionBuilder.getConnectionPassword(), "admin");
+        assertEquals(configurationBuilder.getConnectionPassword(), "admin");
     }
 
     @Test
     public void testIsEmbeddedLDAPEnabled() throws Exception {
-        assertEquals(configurartionBuilder.isLdapEndpointEnabled(), true);
+        assertEquals(configurationBuilder.isLdapEndpointEnabled(), true);
     }
 
 }

--- a/components/org.wso2.carbon.identity.inbound.ldap/src/test/resources/ldap-endpointconfig.xml
+++ b/components/org.wso2.carbon.identity.inbound.ldap/src/test/resources/ldap-endpointconfig.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<LDAPEndPointConfig>
+  <enable>true</enable>
+  <port>10390</port>
+  <instanceId>default</instanceId>
+  <connectionPassword>admin</connectionPassword>
+  <workingDirectory>.</workingDirectory>
+  <allowAnonymousAccess>false</allowAnonymousAccess>
+  <accessControlEnabled>true</accessControlEnabled>
+  <denormalizeOpAttrsEnabled>false</denormalizeOpAttrsEnabled>
+  <maxPDUSize>2000000</maxPDUSize>
+  <saslHostName>localhost</saslHostName>
+  <saslPrincipalName>ldap/localhost@EXAMPLE.COM</saslPrincipalName>
+</LDAPEndPointConfig>

--- a/components/org.wso2.carbon.identity.inbound.ldap/src/test/resources/testng.xml
+++ b/components/org.wso2.carbon.identity.inbound.ldap/src/test/resources/testng.xml
@@ -21,7 +21,7 @@
     <test name="OAuth2EndpointTestsWithDebugEnabled" preserve-order="true" parallel="false">
         <parameter name="log-level" value="debug"/>
         <classes>
-            <class name="org.wso2.carbon.identity.inbound.ldap.utils.ConfigurartionBuilderTest" />
+            <class name="org.wso2.carbon.identity.inbound.ldap.utils.ConfigurationBuilderTest" />
             <class name="org.wso2.carbon.identity.inbound.ldap.provider.IdentityLDAPManagerTest" />
             <class name="org.wso2.carbon.identity.inbound.ldap.provider.LDAPAttributeMapperTest" />
         </classes>

--- a/components/org.wso2.carbon.identity.inbound.ldap/src/test/resources/testng.xml
+++ b/components/org.wso2.carbon.identity.inbound.ldap/src/test/resources/testng.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+
+<suite name="Identity-inbound-provisioning-ldap">
+    <test name="OAuth2EndpointTestsWithDebugEnabled" preserve-order="true" parallel="false">
+        <parameter name="log-level" value="debug"/>
+        <classes>
+            <class name="org.wso2.carbon.identity.inbound.ldap.utils.ConfigurartionBuilderTest" />
+            <class name="org.wso2.carbon.identity.inbound.ldap.provider.IdentityLDAPManagerTest" />
+            <class name="org.wso2.carbon.identity.inbound.ldap.provider.LDAPAttributeMapperTest" />
+        </classes>
+    </test>
+</suite>

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,356 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <parent>
+        <groupId>org.wso2</groupId>
+        <artifactId>wso2</artifactId>
+        <version>1</version>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.wso2.carbon.identity.inbound.provisioning.ldap</groupId>
+    <artifactId>identity-inbound-provisioning-ldap</artifactId>
+    <packaging>pom</packaging>
+    <version>1.0.0-SNAPSHOT</version>
+    <name>identity-inbound-provisioning-ldap</name>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.wso2.carbon</groupId>
+                <artifactId>org.wso2.carbon.core</artifactId>
+                <version>${carbon.kernel.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.framework</groupId>
+                <artifactId>org.wso2.carbon.identity.base</artifactId>
+                <version>${carbon.identity.framework.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity</groupId>
+                <artifactId>org.wso2.carbon.identity.application.common</artifactId>
+                <version>${org.wso2.carbon.identity.application.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity</groupId>
+                <artifactId>org.wso2.carbon.identity.application.mgt</artifactId>
+                <version>${org.wso2.carbon.identity.application.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>commons-io.wso2</groupId>
+                <artifactId>commons-io</artifactId>
+                <version>${commons-io.wso2.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.wso2.carbon.identity.userstore.ldapendpoint</groupId>
+                <artifactId>org.wso2.carbon.ldap.org.wso2.carbon.identity.inbound.ldap.endpoint</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.wso2.orbit.org.apache.directory</groupId>
+                <artifactId>apacheds</artifactId>
+                <version>${orbit.version.apacheds}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.directory.server</groupId>
+                <artifactId>apacheds-protocol-ldap</artifactId>
+                <version>${apacheds.core.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.directory.server</groupId>
+                <artifactId>apacheds-protocol-kerberos</artifactId>
+                <version>${apacheds.core.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.directory.server</groupId>
+                <artifactId>apacheds-interceptor-kerberos</artifactId>
+                <version>${apacheds.core.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.directory.server</groupId>
+                <artifactId>apacheds-org.wso2.carbon.identity.inbound.ldap.endpoint.interceptor-kerberos</artifactId>
+                <version>${apacheds.core.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.directory.server</groupId>
+                <artifactId>apacheds-core-annotations</artifactId>
+                <version>${apacheds.core.version}</version>
+            </dependency>
+
+            <dependency>
+                <artifactId>api-ldap-model</artifactId>
+                <groupId>org.apache.directory.api</groupId>
+                <version>${apacheds.api.version}</version>
+            </dependency>
+
+            <dependency>
+                <artifactId>api-util</artifactId>
+                <groupId>org.apache.directory.api</groupId>
+                <version>${apacheds.api.version}</version>
+            </dependency>
+
+
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+                <version>${org.slf4j.verison}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-log4j12</artifactId>
+                <version>${org.slf4j.verison}</version>
+            </dependency>
+            <dependency>
+                <groupId>log4j</groupId>
+                <artifactId>log4j</artifactId>
+                <version>${log4j.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>org.apache.felix.scr.ds-annotations</artifactId>
+                <version>${apache.felix.scr.ds.annotations.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.w3c</groupId>
+                <artifactId>dom</artifactId>
+                <version>${dom.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.powermock</groupId>
+                <artifactId>powermock-module-testng</artifactId>
+                <version>${powermock.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.powermock</groupId>
+                <artifactId>powermock-api-mockito</artifactId>
+                <version>${powermock.version}</version>
+                <scope>test</scope>
+            </dependency>
+
+
+            <dependency>
+                <groupId>junit</groupId>
+                <artifactId>junit</artifactId>
+                <version>${junit.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.testng</groupId>
+                <artifactId>testng</artifactId>
+                <version>${testng.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jacoco</groupId>
+                <artifactId>org.jacoco.agent</artifactId>
+                <classifier>runtime</classifier>
+                <version>${jacoco.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.felix</groupId>
+                    <artifactId>maven-scr-plugin</artifactId>
+                    <version>${maven.scr.plugin.version}</version>
+                    <executions>
+                        <execution>
+                            <id>generate-scr-scrdescriptor</id>
+                            <goals>
+                                <goal>scr</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.felix</groupId>
+                    <artifactId>maven-bundle-plugin</artifactId>
+                    <version>${maven.bundle.plugin.version}</version>
+                    <extensions>true</extensions>
+                    <configuration>
+                        <obrRepository>NONE</obrRepository>
+                        <instructions>
+                            <SCM-Revision>${buildNumber}</SCM-Revision>
+                        </instructions>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-release-plugin</artifactId>
+                <configuration>
+                    <preparationGoals>clean install</preparationGoals>
+                    <autoVersionSubmodules>true</autoVersionSubmodules>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${maven.compiler.plugin.version}</version>
+                <inherited>true</inherited>
+                <configuration>
+                    <encoding>UTF-8</encoding>
+                    <source>1.7</source>
+                    <target>1.7</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>buildnumber-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+    <repositories>
+        <repository>
+            <id>wso2-nexus</id>
+            <name>WSO2 org.wso2.carbon.identity.inbound.ldap.endpoint.internal Repository</name>
+            <url>http://maven.wso2.org/nexus/content/groups/wso2-public/</url>
+            <releases>
+                <enabled>true</enabled>
+                <updatePolicy>daily</updatePolicy>
+                <checksumPolicy>ignore</checksumPolicy>
+            </releases>
+        </repository>
+
+        <repository>
+            <id>wso2.releases</id>
+            <name>WSO2 org.wso2.carbon.identity.inbound.ldap.endpoint.internal Repository</name>
+            <url>http://maven.wso2.org/nexus/content/repositories/releases/</url>
+            <releases>
+                <enabled>true</enabled>
+                <updatePolicy>daily</updatePolicy>
+                <checksumPolicy>ignore</checksumPolicy>
+            </releases>
+        </repository>
+
+        <repository>
+            <id>wso2.snapshots</id>
+            <name>Apache Snapshot Repository</name>
+            <url>http://maven.wso2.org/nexus/content/repositories/snapshots/</url>
+            <snapshots>
+                <enabled>true</enabled>
+                <updatePolicy>daily</updatePolicy>
+            </snapshots>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+        </repository>
+    </repositories>
+
+    <pluginRepositories>
+        <pluginRepository>
+            <id>wso2.releases</id>
+            <name>WSO2 org.wso2.carbon.identity.inbound.ldap.endpoint.internal Repository</name>
+            <url>http://maven.wso2.org/nexus/content/repositories/releases/</url>
+            <releases>
+                <enabled>true</enabled>
+                <updatePolicy>daily</updatePolicy>
+                <checksumPolicy>ignore</checksumPolicy>
+            </releases>
+        </pluginRepository>
+
+        <pluginRepository>
+            <id>wso2.snapshots</id>
+            <name>WSO2 Snapshot Repository</name>
+            <url>http://maven.wso2.org/nexus/content/repositories/snapshots/</url>
+            <snapshots>
+                <enabled>true</enabled>
+                <updatePolicy>daily</updatePolicy>
+            </snapshots>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+        </pluginRepository>
+        <pluginRepository>
+            <id>wso2-nexus</id>
+            <name>WSO2 org.wso2.carbon.identity.inbound.ldap.endpoint.internal Repository</name>
+            <url>http://maven.wso2.org/nexus/content/groups/wso2-public/</url>
+            <releases>
+                <enabled>true</enabled>
+                <updatePolicy>daily</updatePolicy>
+                <checksumPolicy>ignore</checksumPolicy>
+            </releases>
+        </pluginRepository>
+    </pluginRepositories>
+
+    <properties>
+        <carbon.kernel.version>4.4.7</carbon.kernel.version>
+        <org.wso2.carbon.identity.inbound.ldap.package.export.version>${project.version}
+        </org.wso2.carbon.identity.inbound.ldap.package.export.version>
+        <carbon.identity.framework.version>5.7.0</carbon.identity.framework.version>
+        <commons-io.wso2.version>2.4.0.wso2v1</commons-io.wso2.version>
+
+        <orbit.version.apacheds>1.5.7.wso2v5</orbit.version.apacheds>
+        <apacheds.core.version>1.5.7</apacheds.core.version>
+        <apacheds.api.version>1.0.0</apacheds.api.version>
+
+        <org.slf4j.verison>1.6.1</org.slf4j.verison>
+        <log4j.version>1.2.13</log4j.version>
+
+
+        <org.wso2.carbon.identity.application.version>5.0.8</org.wso2.carbon.identity.application.version>
+        <maven.scr.plugin.version>1.16.0</maven.scr.plugin.version>
+        <maven.bundle.plugin.version>2.4.0</maven.bundle.plugin.version>
+        <maven.compiler.plugin.version>2.3.1</maven.compiler.plugin.version>
+        <carbon.p2.plugin.version>1.5.3</carbon.p2.plugin.version>
+
+        <carbon.kernel.package.import.version.range>[4.4.0, 5.0.0)</carbon.kernel.package.import.version.range>
+        <carbon.logging.imp.pkg.version.range>[1.2.17, 2.0.0)</carbon.logging.imp.pkg.version.range>
+        <carbon.user.api.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.user.api.imp.pkg.version.range>
+
+        <carbon.identity.framework.package.import.version.range>[5.0.0, 6.0.0)
+        </carbon.identity.framework.package.import.version.range>
+
+        <commons.io.wso2.osgi.version.range>[2.4.0,3.0.0)</commons.io.wso2.osgi.version.range>
+        <osgi.framework.imp.pkg.version.range>[1.7.0, 2.0.0)</osgi.framework.imp.pkg.version.range>
+        <apacheds.imp.pkg.version.range>[1.5.7,2.0.0)</apacheds.imp.pkg.version.range>
+        <org.slf4j.imp.pkg.version.range>[1.6.1,2.0.0)</org.slf4j.imp.pkg.version.range>
+        <axiom.osgi.version.range>[1.2.11, 2.0.0)</axiom.osgi.version.range>
+
+        <junit.version>4.12</junit.version>
+        <testng.version>6.9.10</testng.version>
+        <jacoco.version>0.7.9</jacoco.version>
+        <powermock.version>1.6.6</powermock.version>
+
+
+        <apache.felix.scr.ds.annotations.version>1.2.4</apache.felix.scr.ds.annotations.version>
+
+        <osgi.service.component.imp.pkg.version.range>[1.2.0, 2.0.0)</osgi.service.component.imp.pkg.version.range>
+        <dom.version>2.3.0-jaxb-1.0.6</dom.version>
+    </properties>
+
+    <modules>
+        <module>components/org.wso2.carbon.identity.inbound.ldap</module>
+    </modules>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,6 @@
                 <version>${apacheds.api.version}</version>
             </dependency>
 
-
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
@@ -147,13 +146,6 @@
                 <artifactId>powermock-api-mockito</artifactId>
                 <version>${powermock.version}</version>
                 <scope>test</scope>
-            </dependency>
-
-
-            <dependency>
-                <groupId>junit</groupId>
-                <artifactId>junit</artifactId>
-                <version>${junit.version}</version>
             </dependency>
 
             <dependency>
@@ -231,79 +223,6 @@
         </plugins>
     </build>
 
-    <repositories>
-        <repository>
-            <id>wso2-nexus</id>
-            <name>WSO2 org.wso2.carbon.identity.inbound.ldap.endpoint.internal Repository</name>
-            <url>http://maven.wso2.org/nexus/content/groups/wso2-public/</url>
-            <releases>
-                <enabled>true</enabled>
-                <updatePolicy>daily</updatePolicy>
-                <checksumPolicy>ignore</checksumPolicy>
-            </releases>
-        </repository>
-
-        <repository>
-            <id>wso2.releases</id>
-            <name>WSO2 org.wso2.carbon.identity.inbound.ldap.endpoint.internal Repository</name>
-            <url>http://maven.wso2.org/nexus/content/repositories/releases/</url>
-            <releases>
-                <enabled>true</enabled>
-                <updatePolicy>daily</updatePolicy>
-                <checksumPolicy>ignore</checksumPolicy>
-            </releases>
-        </repository>
-
-        <repository>
-            <id>wso2.snapshots</id>
-            <name>Apache Snapshot Repository</name>
-            <url>http://maven.wso2.org/nexus/content/repositories/snapshots/</url>
-            <snapshots>
-                <enabled>true</enabled>
-                <updatePolicy>daily</updatePolicy>
-            </snapshots>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-        </repository>
-    </repositories>
-
-    <pluginRepositories>
-        <pluginRepository>
-            <id>wso2.releases</id>
-            <name>WSO2 org.wso2.carbon.identity.inbound.ldap.endpoint.internal Repository</name>
-            <url>http://maven.wso2.org/nexus/content/repositories/releases/</url>
-            <releases>
-                <enabled>true</enabled>
-                <updatePolicy>daily</updatePolicy>
-                <checksumPolicy>ignore</checksumPolicy>
-            </releases>
-        </pluginRepository>
-
-        <pluginRepository>
-            <id>wso2.snapshots</id>
-            <name>WSO2 Snapshot Repository</name>
-            <url>http://maven.wso2.org/nexus/content/repositories/snapshots/</url>
-            <snapshots>
-                <enabled>true</enabled>
-                <updatePolicy>daily</updatePolicy>
-            </snapshots>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-        </pluginRepository>
-        <pluginRepository>
-            <id>wso2-nexus</id>
-            <name>WSO2 org.wso2.carbon.identity.inbound.ldap.endpoint.internal Repository</name>
-            <url>http://maven.wso2.org/nexus/content/groups/wso2-public/</url>
-            <releases>
-                <enabled>true</enabled>
-                <updatePolicy>daily</updatePolicy>
-                <checksumPolicy>ignore</checksumPolicy>
-            </releases>
-        </pluginRepository>
-    </pluginRepositories>
-
     <properties>
         <carbon.kernel.version>4.4.7</carbon.kernel.version>
         <org.wso2.carbon.identity.inbound.ldap.package.export.version>${project.version}
@@ -317,7 +236,6 @@
 
         <org.slf4j.verison>1.6.1</org.slf4j.verison>
         <log4j.version>1.2.13</log4j.version>
-
 
         <org.wso2.carbon.identity.application.version>5.0.8</org.wso2.carbon.identity.application.version>
         <maven.scr.plugin.version>1.16.0</maven.scr.plugin.version>
@@ -342,7 +260,6 @@
         <testng.version>6.9.10</testng.version>
         <jacoco.version>0.7.9</jacoco.version>
         <powermock.version>1.6.6</powermock.version>
-
 
         <apache.felix.scr.ds.annotations.version>1.2.4</apache.felix.scr.ds.annotations.version>
 

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,8 +1,9 @@
 ## Purpose
-> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.
-
+> LDAP is a core protocol that is used to store user, role, and group information.Identity server already supports connecting to LDAP supported authz systems for authentication and authorization. The idea of this project is to make IS itself act as a LDAP protocol provider.
 ## Goals
-> Describe the solutions that this feature/fix will introduce to resolve the problems described above
+> The general model adopted by this protocol is one of clients performing protocol operations against servers.  In this model, a client send a protocol request describing the operation to be performed to a server.  The server is then responsible for performing the necessary operation(s) in the Directory.Protocol operation are exchanged at the LDAP message layer.For the purposes of protocol exchanges, all protocol operations are encapsulated in a common envelope, the LDAPMessage.
+
+Here capture the LDAPmessage  at LDAP endpoint and Identify the message element and map it into java objects. IS  can use these objects to do operation  with JDBC, MySQL,  LDAP or any other type of database.
 
 ## Approach
 > Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -2,8 +2,7 @@
 > LDAP is a core protocol that is used to store user, role, and group information.Identity server already supports connecting to LDAP supported authz systems for authentication and authorization. The idea of this project is to make IS itself act as a LDAP protocol provider.
 ## Goals
 > The general model adopted by this protocol is one of clients performing protocol operations against servers.  In this model, a client send a protocol request describing the operation to be performed to a server.  The server is then responsible for performing the necessary operation(s) in the Directory.Protocol operation are exchanged at the LDAP message layer.For the purposes of protocol exchanges, all protocol operations are encapsulated in a common envelope, the LDAPMessage.
-
-Here capture the LDAPmessage  at LDAP endpoint and Identify the message element and map it into java objects. IS  can use these objects to do operation  with JDBC, MySQL,  LDAP or any other type of database.
+Here capture the LDAPmessage  at LDAP endpoint and Identify the message element and map it into java objects. Identity server  can use these objects to do operation  with JDBC, MySQL,  LDAP or any other type of database.
 
 ## Approach
 > Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.


### PR DESCRIPTION
## Purpose
> LDAP is a core protocol that is used to store user, role, and group information.Identity server already supports connecting to LDAP supported authz systems for authentication and authorization. The idea of this project is to make IS itself act as a LDAP protocol provider.

## Goals
> In this model, a client send a protocol request describing the operation to be performed to a server.  The server is then responsible for performing the necessary operation(s) in the Directory.Protocol operation are exchanged at the LDAP message layer.For the purposes of protocol exchanges, all protocol operations are encapsulated in a common envelope, the LDAPMessage. Here WSO2 identity server,capture the LDAPmessage  at LDAP endpoint and Identify the message element and map it into java objects. IS  can use these objects to do operation  with JDBC, MySQL,  LDAP or any other type of database. 

## Release note
> This component will be released under 1.0.0 version.

## Documentation
> User guide - https://docs.google.com/a/wso2.com/document/d/1CLXQj8PT6CSM0ZGfws_pcXbht34Gd4B2qUuBL_cOBPY/edit?usp=sharing

